### PR TITLE
Plug-in system for custom project and dataset views

### DIFF
--- a/chat_blueprint.py
+++ b/chat_blueprint.py
@@ -1,0 +1,326 @@
+import json
+import os
+
+import anthropic
+
+_anthropic_kwargs = {}
+if os.getenv("ANTHROPIC_BASE_URL"):
+    _anthropic_kwargs["base_url"] = os.getenv("ANTHROPIC_BASE_URL")
+if os.getenv("ANTHROPIC_AUTH_TOKEN"):
+    _anthropic_kwargs["auth_token"] = os.getenv("ANTHROPIC_AUTH_TOKEN")
+else:
+    _anthropic_kwargs["api_key"] = os.getenv("ANTHROPIC_API_KEY", "not-required")
+
+anthropic_client = anthropic.Anthropic(**_anthropic_kwargs)
+
+from flask import (
+    Blueprint, abort, current_app, render_template,
+    request, Response, stream_with_context,
+)
+
+CHAT_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-3-5-haiku-20241022")
+
+CHAT_TOOL_DEFS = [
+    {
+        "name": "get_sample",
+        "description": "Retrieve full details for a single sample by its unique ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "sample_id": {"type": "string", "description": "The unique_id of the sample"}
+            },
+            "required": ["sample_id"]
+        }
+    },
+    {
+        "name": "get_dataset",
+        "description": "Retrieve full details (including scientific metadata) for a dataset by its unique ID.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "dataset_id": {"type": "string", "description": "The unique_id of the dataset"}
+            },
+            "required": ["dataset_id"]
+        }
+    },
+    {
+        "name": "search_samples",
+        "description": "Search samples in the project by name substring.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Substring to match against sample names"}
+            },
+            "required": ["query"]
+        }
+    },
+    {
+        "name": "search_datasets",
+        "description": "Search datasets in the project by name or measurement type substring.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Substring to match against dataset names or measurement types"}
+            },
+            "required": ["query"]
+        }
+    },
+    {
+        "name": "list_samples_for_dataset",
+        "description": "List all samples associated with a given dataset.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "dataset_id": {"type": "string", "description": "The unique_id of the dataset"}
+            },
+            "required": ["dataset_id"]
+        }
+    },
+    {
+        "name": "get_entity_graph",
+        "description": (
+            "Return the lineage graph for a sample or dataset: its ancestor and descendant samples, "
+            "sample-to-sample relationships, and the datasets associated with each sample. "
+            "Use this to understand provenance, processing history, or what measurements exist for a sample."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entity_type": {"type": "string", "enum": ["sample", "dataset"],
+                                "description": "Whether the ID refers to a sample or a dataset"},
+                "entity_id":   {"type": "string", "description": "The unique_id of the sample or dataset"}
+            },
+            "required": ["entity_type", "entity_id"]
+        }
+    },
+    {
+        "name": "get_thumbnail",
+        "description": "Retrieve and display a thumbnail image for a dataset. Use this when the user asks to see an image, photo, or thumbnail of a dataset.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "dataset_id": {"type": "string", "description": "The unique_id of the dataset"}
+            },
+            "required": ["dataset_id"]
+        }
+    },
+]
+
+
+_FULL_LIST_THRESHOLD = 150
+
+
+def _grouped_summary(items, name_key, type_key, examples=3):
+    """Return grouped-by-type summary lines with a few name examples per group."""
+    groups = {}
+    for it in items:
+        t = it.get(type_key) or 'unknown'
+        groups.setdefault(t, []).append(it)
+    lines = []
+    for t, members in sorted(groups.items()):
+        ex = ', '.join(m[name_key] for m in members[:examples])
+        suffix = f' (e.g. {ex})' if ex else ''
+        lines.append(f"- {t}: {len(members)}{suffix}")
+    return '\n'.join(lines)
+
+
+def build_system_prompt(pc):
+    project_id = pc['project_id']
+    samples = pc.get('samples', [])
+    datasets = pc.get('datasets', [])
+
+    if len(samples) <= _FULL_LIST_THRESHOLD:
+        sample_section = '\n'.join(
+            f"- {s['sample_name']} ({s.get('sample_type', 'unknown')}) [{s['unique_id']}]"
+            for s in samples
+        )
+        sample_note = ''
+    else:
+        sample_section = _grouped_summary(samples, 'sample_name', 'sample_type')
+        sample_note = '\nUse search_samples(query) to locate specific samples by name.'
+
+    if len(datasets) <= _FULL_LIST_THRESHOLD:
+        dataset_section = '\n'.join(
+            f"- {d['dataset_name']} ({d.get('measurement', 'unknown')}) [{d['unique_id']}]"
+            for d in datasets
+        )
+        dataset_note = ''
+    else:
+        dataset_section = _grouped_summary(datasets, 'dataset_name', 'measurement')
+        dataset_note = '\nUse search_datasets(query) to locate specific datasets by name or measurement type.'
+
+    return f"""You are a scientific data assistant for Crucible project '{project_id}'.
+
+## Samples ({len(samples)} total)
+{sample_section}{sample_note}
+
+## Datasets ({len(datasets)} total)
+{dataset_section}{dataset_note}
+
+Use the provided tools to retrieve scientific metadata, sample details, and dataset details \
+when answering questions. Always cite the IDs of the samples or datasets you reference."""
+
+
+def execute_chat_tool(name, inputs, crucible_client, pc, get_entity_graph_nx):
+    try:
+        if name == 'get_sample':
+            result = crucible_client.get_sample(inputs['sample_id'])
+        elif name == 'get_dataset':
+            result = crucible_client.get_dataset(inputs['dataset_id'], include_metadata=True)
+        elif name == 'search_samples':
+            q = inputs['query'].lower()
+            result = [
+                {'id': s['unique_id'], 'name': s['sample_name'], 'type': s.get('sample_type', '')}
+                for s in pc.get('samples', [])
+                if q in s['sample_name'].lower()
+            ]
+        elif name == 'search_datasets':
+            q = inputs['query'].lower()
+            result = [
+                {'id': d['unique_id'], 'name': d['dataset_name'], 'measurement': d.get('measurement', '')}
+                for d in pc.get('datasets', [])
+                if q in d['dataset_name'].lower() or q in d.get('measurement', '').lower()
+            ]
+        elif name == 'list_samples_for_dataset':
+            result = crucible_client.list_samples(dataset_id=inputs['dataset_id'])
+        elif name == 'get_entity_graph':
+            entity_type = inputs['entity_type']
+            entity_id   = inputs['entity_id']
+            G = get_entity_graph_nx(entity_id)
+
+            nodes = []
+            edges = [{'source': src, 'target': tgt} for src, tgt in G.edges()]
+            for node_id, attrs in G.nodes(data=True):
+                ntype = attrs.get('entity_type', entity_type)
+                if ntype == 'sample':
+                    s = pc['samples_by_id'].get(node_id, {})
+                    datasets_for_sample = [
+                        {'id': d['unique_id'], 'name': d.get('dataset_name', ''), 'measurement': d.get('measurement', '')}
+                        for d in s.get('datasets', [])
+                    ]
+                    nodes.append({
+                        'id': node_id,
+                        'name': s.get('sample_name', attrs.get('name', node_id[:13])),
+                        'type': 'sample',
+                        'is_focal': node_id == entity_id,
+                        'datasets': datasets_for_sample
+                    })
+                else:
+                    ds = pc['datasets_by_id'].get(node_id, {})
+                    nodes.append({
+                        'id': node_id,
+                        'name': ds.get('dataset_name', attrs.get('name', node_id[:13])),
+                        'type': 'dataset',
+                        'measurement': ds.get('measurement', ''),
+                        'is_focal': node_id == entity_id
+                    })
+            result = {'nodes': nodes, 'edges': edges}
+        else:
+            result = {'error': f'Unknown tool: {name}'}
+    except Exception as e:
+        result = {'error': str(e)}
+
+    text = json.dumps(result, default=str)
+    return text[:3000] if len(text) > 3000 else text
+
+
+def create_blueprint(auth, helpers):
+    bp = Blueprint('chat', __name__)
+
+    get_project        = helpers['get_project']
+    is_user_in_project = helpers['is_user_in_project']
+    get_entity_graph_nx = helpers['get_entity_graph_nx']
+
+    @bp.route('/<project_id>/chat')
+    @auth.oidc_auth('orcid')
+    def project_chat(project_id):
+        if not is_user_in_project(project_id):
+            abort(403)
+        pc = get_project(project_id)
+        return render_template('chat.html', pc=pc)
+
+    @bp.route('/<project_id>/api/chat', methods=['POST'])
+    @auth.oidc_auth('orcid')
+    def project_chat_api(project_id):
+        if not is_user_in_project(project_id):
+            abort(403)
+
+        body = request.get_json(force=True)
+        history = body.get('history', [])
+
+        pc = get_project(project_id)
+        system_prompt = build_system_prompt(pc)
+
+        def generate():
+            messages = list(history)
+            try:
+                while True:
+                    response = anthropic_client.messages.create(
+                        model=CHAT_MODEL,
+                        system=system_prompt,
+                        messages=messages,
+                        tools=CHAT_TOOL_DEFS,
+                        max_tokens=4096
+                    )
+
+                    for block in response.content:
+                        if block.type == 'text' and block.text:
+                            yield f"data: {json.dumps({'type': 'text', 'delta': block.text})}\n\n"
+
+                    if response.stop_reason == 'tool_use':
+                        assistant_content = []
+                        for b in response.content:
+                            if b.type == 'text':
+                                assistant_content.append({'type': 'text', 'text': b.text})
+                            elif b.type == 'tool_use':
+                                assistant_content.append({'type': 'tool_use', 'id': b.id, 'name': b.name, 'input': b.input})
+                        messages.append({'role': 'assistant', 'content': assistant_content})
+
+                        tool_results = []
+                        for block in response.content:
+                            if block.type == 'tool_use':
+                                yield f"data: {json.dumps({'type': 'tool_call', 'name': block.name, 'input': block.input})}\n\n"
+
+                                if block.name == 'get_thumbnail':
+                                    dsid = block.input['dataset_id']
+                                    try:
+                                        thumbs = current_app.crucible_client.get_thumbnails(dsid)
+                                        if thumbs:
+                                            src = f"data:image/png;base64,{thumbs[0]['thumbnail_b64str']}"
+                                            label = pc['datasets_by_id'].get(dsid, {}).get('dataset_name', dsid[:13])
+                                            yield f"data: {json.dumps({'type': 'image', 'src': src, 'label': label})}\n\n"
+                                            result_text = f"Thumbnail for '{label}' retrieved and displayed to the user."
+                                        else:
+                                            result_text = "No thumbnail available for this dataset."
+                                    except Exception as e:
+                                        result_text = f"Failed to retrieve thumbnail: {e}"
+                                else:
+                                    result_text = execute_chat_tool(
+                                        block.name, block.input,
+                                        current_app.crucible_client, pc,
+                                        get_entity_graph_nx,
+                                    )
+
+                                yield f"data: {json.dumps({'type': 'tool_result', 'name': block.name, 'result': result_text})}\n\n"
+                                tool_results.append({
+                                    'type': 'tool_result',
+                                    'tool_use_id': block.id,
+                                    'content': result_text
+                                })
+
+                        messages.append({'role': 'user', 'content': tool_results})
+                    else:
+                        break
+
+            except Exception as e:
+                yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done'})}\n\n"
+
+        return Response(
+            stream_with_context(generate()),
+            mimetype='text/event-stream',
+            headers={'X-Accel-Buffering': 'no', 'Cache-Control': 'no-cache'},
+        )
+
+    return bp

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -5,7 +5,6 @@ import tempfile
 import anthropic
 import networkx as nx
 import flask
-import pandas
 import markdown
 import requests
 from flask import Flask, render_template, jsonify, abort, redirect, request, Response, stream_with_context
@@ -186,6 +185,7 @@ def project_overview(project_id):
                         sample_info=sorted(pc['samples_by_name'].values(), key=lambda x:x['sample_name']),
                         samples_by_type=samples_by_type,
                         datasets_by_type=datasets_by_type,
+                        custom_views=project_views.get_views(project_id),
                         )
 
 # @app.route("/<project_id>/update-cache")
@@ -974,114 +974,12 @@ def project_chat_api(project_id):
                     headers={'X-Accel-Buffering': 'no', 'Cache-Control': 'no-cache'})
 
 
-# 10_perovskite specific views
-
-project_id = "10k_perovskites"
-@app.route(f"/10k_perovskites/view/overview")
-@auth.oidc_auth('orcid')
-def overview10k():
-    pc = get_project(project_id, include_metadata=True)
-    G = get_project_sample_graph(project_id)
-
-    if not is_user_in_project(project_id):
-        abort(403)
-
-    thin_films = [s for s in pc['samples'] 
-                  if s['sample_name'].startswith('TF')]
-    thin_films.sort(key= lambda x: x['sample_name'])
-
-    rows = []
-
-    for s in thin_films:
-
-        # all ancestors
-        ancestors = nx.ancestors(G, s['unique_id'])
-        ancestors = [pc['samples_by_id'][sid] for sid in ancestors]
-        # all descendants
-        descendants = nx.descendants(G, s['unique_id'])
-        descendants = [pc['samples_by_id'][sid] for sid in descendants]
-
-        # Find the solid precursor samples that were used to make this thin film sample
-        solid_precursors = [sample for sample in ancestors if sample['sample_name'].startswith('SP')]
-        
-        # Capture their compositions from the 'Solid Precursor synthesis' dataset
-        precursor_compositions = []
-        try:
-            for sp in solid_precursors:
-                for ds in sp['datasets']:
-                    if ds['measurement'] == 'Solid Precursor synthesis':
-                        full_ds = pc['datasets_by_id'][ds['unique_id']]
-                        material = full_ds['scientific_metadata']['name']
-                        precursor_compositions.append(material)
-        except Exception as err:
-            print(f"Failed to get solid precursor details {s['sample_name']}: {err}")
-        
-        if len(precursor_compositions) != 2:
-            #print(f"Warning: expected 2 solid precursors for {s['sample_name']}, found {len(precursor_compositions)}")
-            if len(precursor_compositions) < 2:
-                precursor_compositions += [None] * (2 - len(precursor_compositions))
-        
-        sr = [ds for ds in s['datasets'] if ds['measurement'] == 'spin_run']
-        if sr:
-            print(sr)
-            sr = pc['datasets_by_id'][sr[0]['unique_id']]
-            anneal_temp = sr['scientific_metadata']['heater_sv_temp']
-        else: 
-            anneal_temp = '?'
-
-        row = {
-            'thin_film_sample_name': s['sample_name'],
-            'thin_film_unique_id': s['unique_id'],
-            'sp_A': precursor_compositions[0],
-            'sp_B': precursor_compositions[1],
-            'anneal_temp': anneal_temp,
-        }
-        #print(row)
-        rows.append(row)    
-
-    df = pandas.DataFrame(rows)
-
-    return render_template(f'proj10k_templates/overview.html', 
-                           pc=pc,
-                           tfs=thin_films, df=df)
-
-@app.route(f"/10k_perovskites/view/thinfilm-gallery")
-@auth.oidc_auth('orcid')
-def thinfilm_gallery_10k():
-    project_id = "10k_perovskites"
-    if not is_user_in_project(project_id):
-        abort(403)
-    pc = get_project(project_id)
-
-    thin_films = [s for s in pc['samples'] 
-                  if s['sample_name'].startswith('TF')]
-    thin_films.sort(key= lambda x: x['sample_name'])
-
-    # Collect all image dataset IDs then batch-fetch thumbnails in one request
-    img_dsid = {
-        tf['unique_id']: next(
-            (ds['unique_id'] for ds in tf['datasets'] if ds['measurement'] == 'sample well image'),
-            None
-        )
-        for tf in thin_films
-    }
-    batch = {}
-    dataset_ids = [dsid for dsid in img_dsid.values() if dsid]
-    if dataset_ids:
-        try:
-            batch = app.crucible_client._request("POST", "/datasets/first_thumbnails", json=dataset_ids)
-        except Exception:
-            pass
-
-    tf_thumbs = []
-    for tf in thin_films:
-        dsid = img_dsid.get(tf['unique_id'])
-        tn = dict(batch.get(dsid, {})) if dsid else {}
-        tn['sample_name'] = tf['sample_name']
-        tn['sample_url'] = f"/10k_perovskites/sample-graph/{tf['unique_id']}"
-        tf_thumbs.append(tn)
-            
-
-
-
-    return render_template('proj10k_templates/thinfilm-gallery.html', tf_thumbs=tf_thumbs)
+# Project-specific views are loaded from the project_views/ package.
+import project_views
+project_views.register_all(app, auth, {
+    'get_project': get_project,
+    'is_user_in_project': is_user_in_project,
+    'get_project_sample_graph': get_project_sample_graph,
+    'get_sample_lineage_graph': get_sample_lineage_graph,
+    'get_entity_graph_nx': get_entity_graph_nx,
+})

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -489,6 +489,51 @@ def entity_graph_data(project_id, entity_type, entity_id):
     })
 
 
+@app.route("/<project_id>/project-graph")
+@auth.oidc_auth('orcid')
+def project_graph(project_id):
+    if not is_user_in_project(project_id):
+        abort(403)
+    pc = get_project(project_id)
+    return render_template('project_graph.html', pc=pc)
+
+
+@app.route("/<project_id>/api/project-graph-data")
+@auth.oidc_auth('orcid')
+def project_graph_data(project_id):
+    if not is_user_in_project(project_id):
+        abort(403)
+
+    pc = get_project(project_id)
+    node_link_data = app.crucible_client._request("GET", f"/projects/{project_id}/entity_graph")
+    G = nx.node_link_graph(node_link_data)
+
+    nodes = []
+    edges = [{'source': src, 'target': tgt} for src, tgt in G.edges()]
+
+    for node_id, attrs in G.nodes(data=True):
+        if attrs.get('entity_type') == 'sample':
+            sample = pc['samples_by_id'].get(node_id, {})
+            nodes.append({
+                'id': node_id,
+                'label': sample.get('sample_name', attrs.get('name', node_id[:13])),
+                'type': 'sample',
+                'description': sample.get('description', ''),
+                'url': f'/{project_id}/sample-graph/{node_id}'
+            })
+        else:
+            ds = pc['datasets_by_id'].get(node_id, {})
+            nodes.append({
+                'id': node_id,
+                'label': ds.get('dataset_name', attrs.get('name', node_id[:13])),
+                'type': 'dataset',
+                'measurement': ds.get('measurement', ''),
+                'url': f'/{project_id}/dataset/{node_id}'
+            })
+
+    return jsonify({'nodes': nodes, 'edges': edges})
+
+
 @app.route("/<project_id>/api/samples")
 @auth.oidc_auth('orcid')
 def api_samples(project_id):

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -2,12 +2,11 @@ import os
 import re
 import json
 import tempfile
-import anthropic
 import networkx as nx
 import flask
 import markdown
 import requests
-from flask import Flask, render_template, jsonify, abort, redirect, request, Response, stream_with_context
+from flask import Flask, render_template, jsonify, abort, redirect, request
 from flask_qrcode import QRcode
 from flask_vite import Vite
 from flask_pyoidc.user_session import UserSession
@@ -46,15 +45,6 @@ app.crucible_client = CrucibleClient(
     api_url=crucible_api_url,
     api_key=crucible_api_key # v3
 )
-
-_anthropic_kwargs = {}
-if os.getenv("ANTHROPIC_BASE_URL"):
-    _anthropic_kwargs["base_url"] = os.getenv("ANTHROPIC_BASE_URL")
-if os.getenv("ANTHROPIC_AUTH_TOKEN"):
-    _anthropic_kwargs["auth_token"] = os.getenv("ANTHROPIC_AUTH_TOKEN")
-else:
-    _anthropic_kwargs["api_key"] = os.getenv("ANTHROPIC_API_KEY", "not-required")
-app.anthropic_client = anthropic.Anthropic(**_anthropic_kwargs)
 
 #flask-pyoidc config
 app.config.update(
@@ -678,316 +668,22 @@ def error(error=None, error_description=None):
 
 # ── LLM Chat ──────────────────────────────────────────────────────────────────
 
-CHAT_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-3-5-haiku-20241022")
-
-CHAT_TOOL_DEFS = [
-    {
-        "name": "get_sample",
-        "description": "Retrieve full details for a single sample by its unique ID.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "sample_id": {"type": "string", "description": "The unique_id of the sample"}
-            },
-            "required": ["sample_id"]
-        }
-    },
-    {
-        "name": "get_dataset",
-        "description": "Retrieve full details (including scientific metadata) for a dataset by its unique ID.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "dataset_id": {"type": "string", "description": "The unique_id of the dataset"}
-            },
-            "required": ["dataset_id"]
-        }
-    },
-    {
-        "name": "search_samples",
-        "description": "Search samples in the project by name substring.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "Substring to match against sample names"}
-            },
-            "required": ["query"]
-        }
-    },
-    {
-        "name": "search_datasets",
-        "description": "Search datasets in the project by name or measurement type substring.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "Substring to match against dataset names or measurement types"}
-            },
-            "required": ["query"]
-        }
-    },
-    {
-        "name": "list_samples_for_dataset",
-        "description": "List all samples associated with a given dataset.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "dataset_id": {"type": "string", "description": "The unique_id of the dataset"}
-            },
-            "required": ["dataset_id"]
-        }
-    },
-    {
-        "name": "get_entity_graph",
-        "description": (
-            "Return the lineage graph for a sample or dataset: its ancestor and descendant samples, "
-            "sample-to-sample relationships, and the datasets associated with each sample. "
-            "Use this to understand provenance, processing history, or what measurements exist for a sample."
-        ),
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "entity_type": {"type": "string", "enum": ["sample", "dataset"],
-                                "description": "Whether the ID refers to a sample or a dataset"},
-                "entity_id":   {"type": "string", "description": "The unique_id of the sample or dataset"}
-            },
-            "required": ["entity_type", "entity_id"]
-        }
-    },
-    {
-        "name": "get_thumbnail",
-        "description": "Retrieve and display a thumbnail image for a dataset. Use this when the user asks to see an image, photo, or thumbnail of a dataset.",
-        "input_schema": {
-            "type": "object",
-            "properties": {
-                "dataset_id": {"type": "string", "description": "The unique_id of the dataset"}
-            },
-            "required": ["dataset_id"]
-        }
-    },
-]
-
-
-_FULL_LIST_THRESHOLD = 150   # list individually below this count, summarise above
-
-
-def _grouped_summary(items, name_key, type_key, examples=3):
-    """Return grouped-by-type summary lines with a few name examples per group."""
-    groups = {}
-    for it in items:
-        t = it.get(type_key) or 'unknown'
-        groups.setdefault(t, []).append(it)
-    lines = []
-    for t, members in sorted(groups.items()):
-        ex = ', '.join(m[name_key] for m in members[:examples])
-        suffix = f' (e.g. {ex})' if ex else ''
-        lines.append(f"- {t}: {len(members)}{suffix}")
-    return '\n'.join(lines)
-
-
-def build_system_prompt(pc):
-    project_id = pc['project_id']
-    samples = pc.get('samples', [])
-    datasets = pc.get('datasets', [])
-
-    if len(samples) <= _FULL_LIST_THRESHOLD:
-        sample_section = '\n'.join(
-            f"- {s['sample_name']} ({s.get('sample_type', 'unknown')}) [{s['unique_id']}]"
-            for s in samples
-        )
-        sample_note = ''
-    else:
-        sample_section = _grouped_summary(samples, 'sample_name', 'sample_type')
-        sample_note = '\nUse search_samples(query) to locate specific samples by name.'
-
-    if len(datasets) <= _FULL_LIST_THRESHOLD:
-        dataset_section = '\n'.join(
-            f"- {d['dataset_name']} ({d.get('measurement', 'unknown')}) [{d['unique_id']}]"
-            for d in datasets
-        )
-        dataset_note = ''
-    else:
-        dataset_section = _grouped_summary(datasets, 'dataset_name', 'measurement')
-        dataset_note = '\nUse search_datasets(query) to locate specific datasets by name or measurement type.'
-
-    return f"""You are a scientific data assistant for Crucible project '{project_id}'.
-
-## Samples ({len(samples)} total)
-{sample_section}{sample_note}
-
-## Datasets ({len(datasets)} total)
-{dataset_section}{dataset_note}
-
-Use the provided tools to retrieve scientific metadata, sample details, and dataset details \
-when answering questions. Always cite the IDs of the samples or datasets you reference."""
-
-
-def execute_chat_tool(name, inputs, crucible_client, pc):
-    try:
-        if name == 'get_sample':
-            result = crucible_client.get_sample(inputs['sample_id'])
-        elif name == 'get_dataset':
-            result = crucible_client.get_dataset(inputs['dataset_id'], include_metadata=True)
-        elif name == 'search_samples':
-            q = inputs['query'].lower()
-            result = [
-                {'id': s['unique_id'], 'name': s['sample_name'], 'type': s.get('sample_type', '')}
-                for s in pc.get('samples', [])
-                if q in s['sample_name'].lower()
-            ]
-        elif name == 'search_datasets':
-            q = inputs['query'].lower()
-            result = [
-                {'id': d['unique_id'], 'name': d['dataset_name'], 'measurement': d.get('measurement', '')}
-                for d in pc.get('datasets', [])
-                if q in d['dataset_name'].lower() or q in d.get('measurement', '').lower()
-            ]
-        elif name == 'list_samples_for_dataset':
-            result = crucible_client.list_samples(dataset_id=inputs['dataset_id'])
-        elif name == 'get_entity_graph':
-            entity_type = inputs['entity_type']
-            entity_id   = inputs['entity_id']
-            G = get_entity_graph_nx(entity_id)
-
-            nodes = []
-            edges = [{'source': src, 'target': tgt} for src, tgt in G.edges()]
-            for node_id, attrs in G.nodes(data=True):
-                ntype = attrs.get('entity_type', entity_type)
-                if ntype == 'sample':
-                    s = pc['samples_by_id'].get(node_id, {})
-                    datasets_for_sample = [
-                        {'id': d['unique_id'], 'name': d.get('dataset_name', ''), 'measurement': d.get('measurement', '')}
-                        for d in s.get('datasets', [])
-                    ]
-                    nodes.append({
-                        'id': node_id,
-                        'name': s.get('sample_name', attrs.get('name', node_id[:13])),
-                        'type': 'sample',
-                        'is_focal': node_id == entity_id,
-                        'datasets': datasets_for_sample
-                    })
-                else:
-                    ds = pc['datasets_by_id'].get(node_id, {})
-                    nodes.append({
-                        'id': node_id,
-                        'name': ds.get('dataset_name', attrs.get('name', node_id[:13])),
-                        'type': 'dataset',
-                        'measurement': ds.get('measurement', ''),
-                        'is_focal': node_id == entity_id
-                    })
-            result = {'nodes': nodes, 'edges': edges}
-        else:
-            result = {'error': f'Unknown tool: {name}'}
-    except Exception as e:
-        result = {'error': str(e)}
-
-    text = json.dumps(result, default=str)
-    return text[:3000] if len(text) > 3000 else text
-
-
-@app.route("/<project_id>/chat")
-@auth.oidc_auth('orcid')
-def project_chat(project_id):
-    if not is_user_in_project(project_id):
-        abort(403)
-    pc = get_project(project_id)
-    return render_template('chat.html', pc=pc)
-
-
-@app.route("/<project_id>/api/chat", methods=['POST'])
-@auth.oidc_auth('orcid')
-def project_chat_api(project_id):
-    if not is_user_in_project(project_id):
-        abort(403)
-
-    body = request.get_json(force=True)
-    history = body.get('history', [])   # list of {"role": ..., "content": ...} dicts
-
-    pc = get_project(project_id)
-    system_prompt = build_system_prompt(pc)
-
-    def generate():
-        messages = list(history)
-
-        try:
-            while True:
-                response = app.anthropic_client.messages.create(
-                    model=CHAT_MODEL,
-                    system=system_prompt,
-                    messages=messages,
-                    tools=CHAT_TOOL_DEFS,
-                    max_tokens=4096
-                )
-
-                # Emit text content
-                for block in response.content:
-                    if block.type == 'text' and block.text:
-                        payload = json.dumps({'type': 'text', 'delta': block.text})
-                        yield f"data: {payload}\n\n"
-
-                if response.stop_reason == 'tool_use':
-                    # Append assistant turn — only include fields the API accepts
-                    assistant_content = []
-                    for b in response.content:
-                        if b.type == 'text':
-                            assistant_content.append({'type': 'text', 'text': b.text})
-                        elif b.type == 'tool_use':
-                            assistant_content.append({'type': 'tool_use', 'id': b.id, 'name': b.name, 'input': b.input})
-                    messages.append({'role': 'assistant', 'content': assistant_content})
-
-                    tool_results = []
-                    for block in response.content:
-                        if block.type == 'tool_use':
-                            yield f"data: {json.dumps({'type': 'tool_call', 'name': block.name, 'input': block.input})}\n\n"
-
-                            if block.name == 'get_thumbnail':
-                                dsid = block.input['dataset_id']
-                                try:
-                                    thumbs = app.crucible_client.get_thumbnails(dsid)
-                                    if thumbs:
-                                        src = f"data:image/png;base64,{thumbs[0]['thumbnail_b64str']}"
-                                        label = pc['datasets_by_id'].get(dsid, {}).get('dataset_name', dsid[:13])
-                                        yield f"data: {json.dumps({'type': 'image', 'src': src, 'label': label})}\n\n"
-                                        result_text = f"Thumbnail for '{label}' retrieved and displayed to the user."
-                                    else:
-                                        result_text = "No thumbnail available for this dataset."
-                                except Exception as e:
-                                    result_text = f"Failed to retrieve thumbnail: {e}"
-                            else:
-                                result_text = execute_chat_tool(block.name, block.input, app.crucible_client, pc)
-
-                            yield f"data: {json.dumps({'type': 'tool_result', 'name': block.name, 'result': result_text})}\n\n"
-                            tool_results.append({
-                                'type': 'tool_result',
-                                'tool_use_id': block.id,
-                                'content': result_text
-                            })
-
-                    messages.append({'role': 'user', 'content': tool_results})
-                else:
-                    break
-
-        except Exception as e:
-            yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
-
-        yield f"data: {json.dumps({'type': 'done'})}\n\n"
-
-    return Response(stream_with_context(generate()), mimetype='text/event-stream',
-                    headers={'X-Accel-Buffering': 'no', 'Cache-Control': 'no-cache'})
-
-
-# Project-specific views are loaded from the project_views/ package.
-import project_views
-project_views.register_all(app, auth, {
+_plugin_helpers = {
     'get_project': get_project,
     'is_user_in_project': is_user_in_project,
     'get_project_sample_graph': get_project_sample_graph,
     'get_sample_lineage_graph': get_sample_lineage_graph,
     'get_entity_graph_nx': get_entity_graph_nx,
-})
+}
+
+# Chat
+import chat_blueprint
+app.register_blueprint(chat_blueprint.create_blueprint(auth, _plugin_helpers))
+
+# Project-specific views are loaded from the project_views/ package.
+import project_views
+project_views.register_all(app, auth, _plugin_helpers)
 
 # Dataset measurement-type views are loaded from the dataset_views/ package.
 import dataset_views
-dataset_views.register_all(app, auth, {
-    'get_project': get_project,
-    'is_user_in_project': is_user_in_project,
-})
+dataset_views.register_all(app, auth, _plugin_helpers)

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -2,7 +2,6 @@ import os
 import re
 import json
 import tempfile
-from concurrent.futures import ThreadPoolExecutor
 import anthropic
 import networkx as nx
 import flask
@@ -31,9 +30,10 @@ vite = Vite(app)
 app.project_cache = {}
 app.project_sample_graphs = {}
 
+crucible_api_url = os.getenv("CRUCIBLE_API_URL", "https://crucible.lbl.gov/api/v1")
 crucible_api_key = os.getenv("CRUCIBLE_API_KEY")
 app.crucible_client = CrucibleClient(
-    api_url="https://crucible.lbl.gov/api/v1",
+    api_url=crucible_api_url,
     api_key=crucible_api_key # v3
 )
 
@@ -80,15 +80,14 @@ def get_project_sample_graph(project_id):
     node_link_data = app.crucible_client._request("GET",f"/projects/{project_id}/sample_graph")
     G = nx.node_link_graph(node_link_data)
     return G
-    # if project_id in app.project_cache:
-    #     return app.project_sample_graphs[project_id]
-    # try:
-    #     return load_project_sample_graph(project_id)
-    # except Exception as err:
-    #     print(f"failed to load project cache for {project_id}, regenerating...")
-    #     G = generate_project_sample_graph(project_id,app.crucible_client)
-    #     app.project_sample_graphs[project_id] = G
-    #     return G
+
+def get_sample_lineage_graph(sample_id):
+    node_link_data = app.crucible_client._request("GET", f"/samples/{sample_id}/sample_graph")
+    return nx.node_link_graph(node_link_data)
+
+def get_entity_graph_nx(entity_id):
+    node_link_data = app.crucible_client._request("GET", f"/entity_graph/{entity_id}")
+    return nx.node_link_graph(node_link_data)
 
     
 # def clear_project_cache(project_id):
@@ -199,11 +198,7 @@ def sample_graph(project_id, sample_id):
     pc = get_project(project_id)
 
     print(f"sample_graph")
-    #G = generate_sample_graph(sample_id, app.crucible_client)
-    #Gproject = generate_project_sample_graph(project_id, app.crucible_client)
-    G = get_project_sample_graph(project_id)
-    #G = nx.ego_graph(Gproject,sample_id)
-    #print(G)
+    G = get_sample_lineage_graph(sample_id)
 
     #sample_name = pc['samples_by_id'][sample_id]['sample_name']
     #print(sample_name)
@@ -254,19 +249,11 @@ def sample_graph_data(project_id, sample_id):
         abort(403)
 
     pc = get_project(project_id)
-    G = get_project_sample_graph(project_id)
-
-    # Get the subgraph containing the sample and all its ancestors and descendants
-    descendants = nx.descendants(G, sample_id)
-    ancestors = nx.ancestors(G, sample_id)
-    all_nodes = ancestors | descendants | {sample_id}
-
-    # Create subgraph with only relevant nodes
-    subgraph = G.subgraph(all_nodes)
+    G = get_sample_lineage_graph(sample_id)
 
     # Build nodes list
     nodes = []
-    for node_id in subgraph.nodes():
+    for node_id in G.nodes():
         sample = pc['samples_by_id'].get(node_id, {})
         nodes.append({
             'id': node_id,
@@ -277,7 +264,7 @@ def sample_graph_data(project_id, sample_id):
 
     # Build edges list
     edges = []
-    for source, target in subgraph.edges():
+    for source, target in G.edges():
         edges.append({
             'source': source,
             'target': target
@@ -304,7 +291,11 @@ def dataset(project_id, dsid):
     associated_files = app.crucible_client.get_associated_files(dsid)
     print(associated_files)
 
-    download_links = app.crucible_client.get_dataset_download_links(dsid)
+    try:
+        download_links = app.crucible_client.get_dataset_download_links(dsid)
+    except Exception as err:
+        print(f"Failed to get download links for {dsid}: {err}")
+        download_links = {}
 
     child_datasets = app.crucible_client.list_children_of_dataset(dsid)
     parent_datasets = app.crucible_client.list_parents_of_dataset(dsid)
@@ -446,106 +437,48 @@ def entity_graph_data(project_id, entity_type, entity_id):
         abort(403)
 
     pc = get_project(project_id)
-    G = get_project_sample_graph(project_id)
+    G = get_entity_graph_nx(entity_id)
 
-    # Determine focal sample(s)
-    if entity_type == 'sample':
-        focal_sample_ids = {entity_id}
-    else:
-        focal_sample_ids = {s['unique_id'] for s in app.crucible_client.list_samples(dataset_id=entity_id)}
-
-    # Expand to ancestors + descendants for each focal sample
-    all_sample_ids = set()
-    for sid in focal_sample_ids:
-        if sid in G:
-            all_sample_ids |= nx.ancestors(G, sid) | nx.descendants(G, sid) | {sid}
-        else:
-            all_sample_ids.add(sid)
-
-    subgraph = G.subgraph(all_sample_ids)
     nodes = []
-    edges = []
-    seen = set()
+    edges = [{'source': src, 'target': tgt} for src, tgt in G.edges()]
+    dataset_ids = []
 
-    # Sample nodes
-    for sid in all_sample_ids:
-        seen.add(sid)
-        sample = pc['samples_by_id'].get(sid, {})
-        nodes.append({
-            'id': sid,
-            'label': sample.get('sample_name', sid[:13]),
-            'type': 'sample',
-            'description': sample.get('description', ''),
-            'url': f'/{project_id}/sample-graph/{sid}'
-        })
+    for node_id, attrs in G.nodes(data=True):
+        ntype = attrs.get('entity_type', entity_type)
+        if ntype == 'sample':
+            sample = pc['samples_by_id'].get(node_id, {})
+            nodes.append({
+                'id': node_id,
+                'label': sample.get('sample_name', attrs.get('name', node_id[:13])),
+                'type': 'sample',
+                'description': sample.get('description', ''),
+                'url': f'/{project_id}/sample-graph/{node_id}'
+            })
+        else:
+            dataset_ids.append(node_id)
 
-    # Sample-sample edges
-    for source, target in subgraph.edges():
-        edges.append({'source': source, 'target': target})
-
-    # Collect unique dataset IDs and edges in one pass
-    dataset_meta = {}  # dsid -> ds dict
-
-    # Always include the focal dataset itself (handles datasets with no associated samples)
-    if entity_type == 'dataset' and entity_id not in seen:
-        seen.add(entity_id)
-        dataset_meta[entity_id] = pc['datasets_by_id'].get(entity_id, {'unique_id': entity_id})
-
-    # Add parent and child datasets with their edges
-    if entity_type == 'dataset':
-        try:
-            for parent in app.crucible_client.list_parents_of_dataset(entity_id) or []:
-                pid = parent['unique_id']
-                if pid not in seen:
-                    seen.add(pid)
-                    dataset_meta[pid] = parent
-                edges.append({'source': pid, 'target': entity_id})
-        except Exception:
-            pass
-        try:
-            for child in app.crucible_client.list_children_of_dataset(entity_id) or []:
-                cid = child['unique_id']
-                if cid not in seen:
-                    seen.add(cid)
-                    dataset_meta[cid] = child
-                edges.append({'source': entity_id, 'target': cid})
-        except Exception:
-            pass
-
-    for sid in all_sample_ids:
-        sample = pc['samples_by_id'].get(sid, {})
-        for ds_ref in sample.get('datasets', []):
-            dsid = ds_ref['unique_id']
-            edges.append({'source': sid, 'target': dsid})
-            if dsid not in seen:
-                seen.add(dsid)
-                dataset_meta[dsid] = pc['datasets_by_id'].get(dsid, ds_ref)
-
-    # Fetch all thumbnails in parallel
-    def fetch_thumbnail(dsid):
-        try:
-            thumbs = app.crucible_client.get_thumbnails(dsid)
-            if thumbs:
-                return dsid, f"data:image/png;base64,{thumbs[0]['thumbnail_b64str']}"
-        except Exception:
-            pass
-        return dsid, None
-
+    # Fetch first thumbnail for all dataset nodes in one batch request
     thumbnails = {}
-    if dataset_meta:
-        with ThreadPoolExecutor(max_workers=min(len(dataset_meta), 10)) as executor:
-            for dsid, thumb in executor.map(fetch_thumbnail, dataset_meta):
-                thumbnails[dsid] = thumb
+    if dataset_ids:
+        try:
+            batch = app.crucible_client._request("POST", "/datasets/first_thumbnails", json=dataset_ids)
+            thumbnails = {
+                dsid: f"data:image/png;base64,{data['thumbnail_b64str']}"
+                for dsid, data in batch.items()
+            }
+        except Exception:
+            pass
 
-    # Build dataset nodes
-    for dsid, ds in dataset_meta.items():
+    for node_id in dataset_ids:
+        attrs = G.nodes[node_id]
+        ds = pc['datasets_by_id'].get(node_id, {})
         nodes.append({
-            'id': dsid,
-            'label': ds.get('dataset_name', dsid[:13]),
+            'id': node_id,
+            'label': ds.get('dataset_name', attrs.get('name', node_id[:13])),
             'type': 'dataset',
             'measurement': ds.get('measurement', ''),
-            'url': f'/{project_id}/dataset/{dsid}',
-            'thumbnail': thumbnails.get(dsid)
+            'url': f'/{project_id}/dataset/{node_id}',
+            'thumbnail': thumbnails.get(node_id)
         })
 
     return jsonify({
@@ -611,7 +544,11 @@ def mdnote_edit(project_id, dsid):
 
     # GET: load current markdown content
     associated_files = app.crucible_client.get_associated_files(dsid)
-    download_links = app.crucible_client.get_dataset_download_links(dsid)
+    try:
+        download_links = app.crucible_client.get_dataset_download_links(dsid)
+    except Exception as err:
+        print(f"Failed to get download links for {dsid}: {err}")
+        download_links = {}
     md_content = ''
     for file in associated_files:
         if file['filename'].endswith('.md'):
@@ -819,36 +756,34 @@ def execute_chat_tool(name, inputs, crucible_client, pc):
         elif name == 'get_entity_graph':
             entity_type = inputs['entity_type']
             entity_id   = inputs['entity_id']
-            G = get_project_sample_graph(pc['project_id'])
+            G = get_entity_graph_nx(entity_id)
 
-            if entity_type == 'sample':
-                focal_ids = {entity_id}
-            else:
-                focal_ids = {s['unique_id'] for s in crucible_client.list_samples(dataset_id=entity_id)}
-
-            all_sample_ids = set()
-            for sid in focal_ids:
-                if sid in G:
-                    all_sample_ids |= nx.ancestors(G, sid) | nx.descendants(G, sid) | {sid}
-                else:
-                    all_sample_ids.add(sid)
-
-            subgraph = G.subgraph(all_sample_ids)
             nodes = []
-            for sid in all_sample_ids:
-                s = pc['samples_by_id'].get(sid, {})
-                datasets_for_sample = [
-                    {'id': d['unique_id'], 'name': d.get('dataset_name', ''), 'measurement': d.get('measurement', '')}
-                    for d in s.get('datasets', [])
-                ]
-                nodes.append({
-                    'id': sid,
-                    'name': s.get('sample_name', sid[:13]),
-                    'type': s.get('sample_type', ''),
-                    'is_focal': sid in focal_ids,
-                    'datasets': datasets_for_sample
-                })
-            edges = [{'source': src, 'target': tgt} for src, tgt in subgraph.edges()]
+            edges = [{'source': src, 'target': tgt} for src, tgt in G.edges()]
+            for node_id, attrs in G.nodes(data=True):
+                ntype = attrs.get('entity_type', entity_type)
+                if ntype == 'sample':
+                    s = pc['samples_by_id'].get(node_id, {})
+                    datasets_for_sample = [
+                        {'id': d['unique_id'], 'name': d.get('dataset_name', ''), 'measurement': d.get('measurement', '')}
+                        for d in s.get('datasets', [])
+                    ]
+                    nodes.append({
+                        'id': node_id,
+                        'name': s.get('sample_name', attrs.get('name', node_id[:13])),
+                        'type': 'sample',
+                        'is_focal': node_id == entity_id,
+                        'datasets': datasets_for_sample
+                    })
+                else:
+                    ds = pc['datasets_by_id'].get(node_id, {})
+                    nodes.append({
+                        'id': node_id,
+                        'name': ds.get('dataset_name', attrs.get('name', node_id[:13])),
+                        'type': 'dataset',
+                        'measurement': ds.get('measurement', ''),
+                        'is_focal': node_id == entity_id
+                    })
             result = {'nodes': nodes, 'edges': edges}
         else:
             result = {'error': f'Unknown tool: {name}'}
@@ -1033,19 +968,26 @@ def thinfilm_gallery_10k():
                   if s['sample_name'].startswith('TF')]
     thin_films.sort(key= lambda x: x['sample_name'])
 
+    # Collect all image dataset IDs then batch-fetch thumbnails in one request
+    img_dsid = {
+        tf['unique_id']: next(
+            (ds['unique_id'] for ds in tf['datasets'] if ds['measurement'] == 'sample well image'),
+            None
+        )
+        for tf in thin_films
+    }
+    batch = {}
+    dataset_ids = [dsid for dsid in img_dsid.values() if dsid]
+    if dataset_ids:
+        try:
+            batch = app.crucible_client._request("POST", "/datasets/first_thumbnails", json=dataset_ids)
+        except Exception:
+            pass
+
     tf_thumbs = []
-    # get the thumbnail of the 
     for tf in thin_films:
-        print(tf['sample_name'])
-        img_datasets = [ds for ds in tf['datasets'] if ds['measurement'] == 'sample well image']
-        
-        if img_datasets:
-            ds = img_datasets[0]
-            dsid = ds['unique_id']
-            thumbnails = app.crucible_client.get_thumbnails(dsid)    
-            tn  = thumbnails[0]
-        else:
-            tn = {}
+        dsid = img_dsid.get(tf['unique_id'])
+        tn = dict(batch.get(dsid, {})) if dsid else {}
         tn['sample_name'] = tf['sample_name']
         tn['sample_url'] = f"/10k_perovskites/sample-graph/{tf['unique_id']}"
         tf_thumbs.append(tn)

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -395,13 +395,14 @@ def dataset(project_id, dsid):
 
     return render_template("dataset.html",
                            project_id=project_id, pc=pc, ds=ds,
-                           child_datasets = child_datasets,
-                           parent_datasets = parent_datasets,
+                           child_datasets=child_datasets,
+                           parent_datasets=parent_datasets,
                            samples=samples,
-                            files=associated_files,
-                            download_links=download_links,
+                           files=associated_files,
+                           download_links=download_links,
                            thumbnails=thumbnails,
                            markdown_html=markdown_html,
+                           custom_views=dataset_views.get_views(ds.get('measurement'), project_id, dsid),
                            prev_sibling=prev_sibling,
                            next_sibling=next_sibling,
                            sibling_index=ds_sibling_idx + 1,
@@ -982,4 +983,11 @@ project_views.register_all(app, auth, {
     'get_project_sample_graph': get_project_sample_graph,
     'get_sample_lineage_graph': get_sample_lineage_graph,
     'get_entity_graph_nx': get_entity_graph_nx,
+})
+
+# Dataset measurement-type views are loaded from the dataset_views/ package.
+import dataset_views
+dataset_views.register_all(app, auth, {
+    'get_project': get_project,
+    'is_user_in_project': is_user_in_project,
 })

--- a/dataset_views/__init__.py
+++ b/dataset_views/__init__.py
@@ -1,0 +1,68 @@
+"""
+Pluggable dataset views, keyed by measurement type.
+
+Each module in this package provides a custom view for one or more dataset
+measurement types.  To add a view for a new measurement type, drop a file
+into this directory.  It must expose:
+
+    MEASUREMENT_TYPES : list[str]
+        The measurement type strings this module handles.
+
+    URL_PREFIX : str
+        The blueprint URL prefix, e.g. '/dataset-view/mdnote'.
+
+    LABEL : str
+        Short display label for the link shown on the dataset page.
+
+    create_blueprint(auth, helpers) -> flask.Blueprint
+        Factory that returns a configured Blueprint.  Routes inside should
+        follow the pattern /<project_id>/<dsid>.
+
+Available helpers
+-----------------
+    is_user_in_project(project_id)
+    get_project(project_id, include_metadata=False)
+"""
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+# Maps measurement_type -> list of {url_prefix, label}
+_registry: dict = {}
+
+
+def register_all(app, auth, helpers):
+    """Auto-discover and register every dataset view blueprint."""
+    pkg_dir = Path(__file__).parent
+    for _, name, _ in pkgutil.iter_modules([str(pkg_dir)]):
+        try:
+            module = importlib.import_module(f'dataset_views.{name}')
+        except Exception as err:
+            app.logger.error(f'dataset_views: failed to import {name}: {err}')
+            continue
+        if not (hasattr(module, 'create_blueprint') and hasattr(module, 'MEASUREMENT_TYPES')):
+            continue
+        try:
+            bp = module.create_blueprint(auth, helpers)
+            prefix = module.URL_PREFIX
+            app.register_blueprint(bp, url_prefix=prefix)
+            entry = {
+                'url_prefix': prefix,
+                'label': getattr(module, 'LABEL', module.MEASUREMENT_TYPES[0]),
+            }
+            for mtype in module.MEASUREMENT_TYPES:
+                _registry.setdefault(mtype, []).append(entry)
+            app.logger.info(f'dataset_views: registered {name!r} → {module.MEASUREMENT_TYPES} at {prefix}')
+        except Exception as err:
+            app.logger.error(f'dataset_views: failed to register {name}: {err}')
+
+    app.logger.info(f'dataset_views registry: { {k: [e["label"] for e in v] for k, v in _registry.items()} }')
+
+
+def get_views(measurement: str, project_id: str, dsid: str) -> list:
+    """Return all custom view dicts for a dataset, each with 'url' and 'label'."""
+    return [
+        {'url': f"{entry['url_prefix']}/{project_id}/{dsid}", 'label': entry['label']}
+        for entry in _registry.get(measurement, [])
+    ]

--- a/dataset_views/mdnote.py
+++ b/dataset_views/mdnote.py
@@ -1,0 +1,83 @@
+import os
+import re
+
+import markdown as md_lib
+import requests
+from flask import Blueprint, render_template, abort, current_app
+
+MEASUREMENT_TYPES = ['MDNote']
+URL_PREFIX = '/dataset-view/mdnote'
+LABEL = 'View Note'
+
+
+def _render_markdown(md_content, project_id):
+    """Resolve wiki-style links then convert markdown to HTML."""
+    def replace_dataset_link(match):
+        dataset_id = match.group(1)
+        name = match.group(2) if match.group(2) else f'Dataset-{dataset_id}'
+        return f'[{name}](/{project_id}/dataset/{dataset_id})'
+
+    def replace_sample_link(match):
+        sample_id = match.group(1)
+        name = match.group(2) if match.group(2) else f'Sample-{sample_id}'
+        return f'[{name}](/{project_id}/sample-graph/{sample_id})'
+
+    md_content = re.sub(
+        r'\[\[dataset:([^\]|]+)(?:\|([^\]]+))?\]\]',
+        replace_dataset_link, md_content
+    )
+    md_content = re.sub(
+        r'\[\[sample:([^\]|]+)(?:\|([^\]]+))?\]\]',
+        replace_sample_link, md_content
+    )
+    return md_lib.markdown(md_content, extensions=['extra', 'codehilite', 'tables'])
+
+
+def create_blueprint(auth, helpers):
+    bp = Blueprint('dview_mdnote', __name__)
+
+    is_user_in_project = helpers['is_user_in_project']
+
+    @bp.route('/<project_id>/<dsid>')
+    @auth.oidc_auth('orcid')
+    def view(project_id, dsid):
+        if not is_user_in_project(project_id):
+            abort(403)
+
+        ds = current_app.crucible_client.get_dataset(dsid)
+        associated_files = current_app.crucible_client.get_associated_files(dsid)
+        try:
+            download_links = current_app.crucible_client.get_dataset_download_links(dsid)
+        except Exception:
+            download_links = {}
+
+        markdown_html = None
+        error = None
+
+        md_file = next((f for f in associated_files if f['filename'].endswith('.md')), None)
+        if md_file:
+            md_basename = os.path.basename(md_file['filename'])
+            download_key = f"{ds['unique_id']}/{md_basename}"
+            if download_key in download_links:
+                try:
+                    response = requests.get(download_links[download_key])
+                    if response.status_code == 200:
+                        markdown_html = _render_markdown(response.text, project_id)
+                    else:
+                        error = f'Failed to fetch note (HTTP {response.status_code})'
+                except Exception as err:
+                    error = str(err)
+            else:
+                error = 'Download link not available for this note.'
+        else:
+            error = 'No markdown file found for this dataset.'
+
+        return render_template(
+            'dataset_views/mdnote.html',
+            project_id=project_id,
+            ds=ds,
+            markdown_html=markdown_html,
+            error=error,
+        )
+
+    return bp

--- a/dataset_views/mdnote_raw.py
+++ b/dataset_views/mdnote_raw.py
@@ -1,0 +1,58 @@
+import os
+
+import requests
+from flask import Blueprint, render_template, abort, current_app
+
+MEASUREMENT_TYPES = ['MDNote']
+URL_PREFIX = '/dataset-view/mdnote-raw'
+LABEL = 'Raw Markdown'
+
+
+def create_blueprint(auth, helpers):
+    bp = Blueprint('dview_mdnote_raw', __name__)
+
+    is_user_in_project = helpers['is_user_in_project']
+
+    @bp.route('/<project_id>/<dsid>')
+    @auth.oidc_auth('orcid')
+    def view(project_id, dsid):
+        if not is_user_in_project(project_id):
+            abort(403)
+
+        ds = current_app.crucible_client.get_dataset(dsid)
+        associated_files = current_app.crucible_client.get_associated_files(dsid)
+        try:
+            download_links = current_app.crucible_client.get_dataset_download_links(dsid)
+        except Exception:
+            download_links = {}
+
+        raw_content = None
+        error = None
+
+        md_file = next((f for f in associated_files if f['filename'].endswith('.md')), None)
+        if md_file:
+            md_basename = os.path.basename(md_file['filename'])
+            download_key = f"{ds['unique_id']}/{md_basename}"
+            if download_key in download_links:
+                try:
+                    response = requests.get(download_links[download_key])
+                    if response.status_code == 200:
+                        raw_content = response.text
+                    else:
+                        error = f'Failed to fetch note (HTTP {response.status_code})'
+                except Exception as err:
+                    error = str(err)
+            else:
+                error = 'Download link not available for this note.'
+        else:
+            error = 'No markdown file found for this dataset.'
+
+        return render_template(
+            'dataset_views/mdnote_raw.html',
+            project_id=project_id,
+            ds=ds,
+            raw_content=raw_content,
+            error=error,
+        )
+
+    return bp

--- a/dataset_views/rga_tey_run_plots.py
+++ b/dataset_views/rga_tey_run_plots.py
@@ -1,0 +1,79 @@
+import os
+
+import requests
+from flask import Blueprint, render_template, abort, current_app, Response
+
+MEASUREMENT_TYPES = ['automated_RGA_TEY_run']
+URL_PREFIX = '/dataset-view/rga-tey-run-plots'
+LABEL = 'RGA/TEY Plots'
+
+
+def create_blueprint(auth, helpers):
+    bp = Blueprint('dview_rga_tey_run_plots', __name__)
+
+    is_user_in_project = helpers['is_user_in_project']
+
+    def _get_gcs_url(ds, associated_files, download_links, name_fragment):
+        """Return the download URL for the first .txt file whose basename contains
+        name_fragment *and* that actually has a download link."""
+        for f in associated_files:
+            basename = os.path.basename(f['filename'])
+            if name_fragment in basename and basename.endswith('.txt'):
+                url = download_links.get(f"{ds['unique_id']}/{basename}")
+                if url:
+                    return url
+        return None
+
+    def _fetch_context(dsid):
+        ds = current_app.crucible_client.get_dataset(dsid)
+        associated_files = current_app.crucible_client.get_associated_files(dsid)
+        try:
+            download_links = current_app.crucible_client.get_dataset_download_links(dsid)
+        except Exception:
+            download_links = {}
+        return ds, associated_files, download_links
+
+    @bp.route('/<project_id>/<dsid>')
+    @auth.oidc_auth('orcid')
+    def view(project_id, dsid):
+        if not is_user_in_project(project_id):
+            abort(403)
+
+        ds, associated_files, download_links = _fetch_context(dsid)
+        tey_found = bool(_get_gcs_url(ds, associated_files, download_links, 'TEY'))
+        rga_found = bool(_get_gcs_url(ds, associated_files, download_links, 'RGA_histogram'))
+
+        return render_template(
+            'dataset_views/rga_tey_run_plots.html',
+            project_id=project_id,
+            ds=ds,
+            tey_found=tey_found,
+            rga_found=rga_found,
+        )
+
+    def _proxy(dsid, name_fragment):
+        ds, associated_files, download_links = _fetch_context(dsid)
+        gcs_url = _get_gcs_url(ds, associated_files, download_links, name_fragment)
+        if not gcs_url:
+            abort(404)
+        resp = requests.get(gcs_url, timeout=30)
+        resp.raise_for_status()
+        return Response(resp.content, mimetype='text/plain')
+
+    @bp.route('/<project_id>/<dsid>/tey-data')
+    @auth.oidc_auth('orcid')
+    def tey_data(project_id, dsid):
+        """Proxy: fetches the TEY txt from GCS server-side to avoid CORS."""
+        if not is_user_in_project(project_id):
+            abort(403)
+        return _proxy(dsid, 'TEY')
+
+    @bp.route('/<project_id>/<dsid>/rga-data')
+    @auth.oidc_auth('orcid')
+    def rga_data(project_id, dsid):
+        """Proxy: fetches the RGA histogram txt from GCS server-side to avoid CORS."""
+        if not is_user_in_project(project_id):
+            abort(403)
+        return _proxy(dsid, 'RGA_histogram')
+
+    return bp

--- a/flask_templates/dataset.html
+++ b/flask_templates/dataset.html
@@ -248,6 +248,12 @@
             <i class="bi bi-pencil"></i> Edit Note
         </a>
         {% endif %}
+        {% for cv in custom_views %}
+        <a href="{{ cv.url }}"
+           class="action-link flex-fill py-2 border-end text-secondary">
+            <i class="bi bi-journal-text"></i> {{ cv.label }}
+        </a>
+        {% endfor %}
         <a href="/{{project_id}}/search" class="action-link flex-fill py-2 border-end text-secondary">
             <i class="bi bi-search"></i> Search
         </a>

--- a/flask_templates/dataset_views/mdnote.html
+++ b/flask_templates/dataset_views/mdnote.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}{{ds['dataset_name']}}{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+<style>
+    .markdown-content { line-height: 1.6; max-width: 860px; }
+    .markdown-content h1, .markdown-content h2, .markdown-content h3,
+    .markdown-content h4, .markdown-content h5, .markdown-content h6 {
+        margin-top: 24px; margin-bottom: 16px; font-weight: 600;
+    }
+    .markdown-content h1 { font-size: 2em; border-bottom: 1px solid var(--bs-border-color); padding-bottom: 0.3em; }
+    .markdown-content h2 { font-size: 1.5em; border-bottom: 1px solid var(--bs-border-color); padding-bottom: 0.3em; }
+    .markdown-content h3 { font-size: 1.25em; }
+    .markdown-content p  { margin-bottom: 16px; }
+    .markdown-content ul, .markdown-content ol { margin-bottom: 16px; padding-left: 2em; }
+    .markdown-content li { margin-bottom: 4px; }
+    .markdown-content code { background-color: rgba(175,184,193,0.2); padding: 0.2em 0.4em; border-radius: 6px; font-size: 85%; }
+    .markdown-content pre { background-color: var(--bs-tertiary-bg); border-radius: 6px; padding: 16px; overflow: auto; margin-bottom: 16px; }
+    .markdown-content pre code { background-color: transparent; padding: 0; }
+    .markdown-content blockquote { border-left: 4px solid var(--bs-border-color); padding-left: 16px; margin-left: 0; color: var(--bs-secondary-color); }
+    .markdown-content table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
+    .markdown-content table th, .markdown-content table td { border: 1px solid var(--bs-border-color); padding: 6px 13px; }
+    .markdown-content table th { background-color: var(--bs-tertiary-bg); font-weight: 600; }
+    .markdown-content img { max-width: 100%; height: auto; }
+</style>
+{% endblock %}
+
+{% block breadcrumb %}
+    <li class="breadcrumb-item"><a href="/{{project_id}}/"><b>Project</b> {{project_id}}</a></li>
+    <li class="breadcrumb-item"><a href="/{{project_id}}/dataset/{{ds['unique_id']}}"><b>Dataset</b> {{ds['dataset_name']}}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Note</li>
+{% endblock %}
+
+{% block content %}
+
+<div style="max-width: 860px;">
+    <div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
+        <h1 class="fs-4 fw-semibold mb-0" style="overflow-wrap: break-word;">{{ds['dataset_name']}}</h1>
+        <div class="d-flex gap-2 flex-shrink-0">
+            <a href="/{{project_id}}/dataset/{{ds['unique_id']}}/mdnote-edit"
+               class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-pencil me-1"></i>Edit
+            </a>
+            <a href="/{{project_id}}/dataset/{{ds['unique_id']}}"
+               class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-database me-1"></i>Dataset
+            </a>
+        </div>
+    </div>
+
+    {% if error %}
+    <div class="alert alert-warning">
+        <i class="bi bi-exclamation-triangle me-2"></i>{{ error }}
+    </div>
+    {% elif markdown_html %}
+    <div class="markdown-content">
+        {{ markdown_html | safe }}
+    </div>
+    {% else %}
+    <div class="text-muted fst-italic">This note is empty.</div>
+    {% endif %}
+</div>
+
+{% endblock %}

--- a/flask_templates/dataset_views/mdnote_raw.html
+++ b/flask_templates/dataset_views/mdnote_raw.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}{{ds['dataset_name']}} — Raw{% endblock %}
+
+{% block breadcrumb %}
+    <li class="breadcrumb-item"><a href="/{{project_id}}/"><b>Project</b> {{project_id}}</a></li>
+    <li class="breadcrumb-item"><a href="/{{project_id}}/dataset/{{ds['unique_id']}}"><b>Dataset</b> {{ds['dataset_name']}}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Raw Markdown</li>
+{% endblock %}
+
+{% block content %}
+
+<div style="max-width: 860px;">
+    <div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
+        <h1 class="fs-4 fw-semibold mb-0" style="overflow-wrap: break-word;">{{ds['dataset_name']}}</h1>
+        <div class="d-flex gap-2 flex-shrink-0">
+            <a href="/{{project_id}}/dataset/{{ds['unique_id']}}/mdnote-edit"
+               class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-pencil me-1"></i>Edit
+            </a>
+            <a href="/{{project_id}}/dataset/{{ds['unique_id']}}"
+               class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-database me-1"></i>Dataset
+            </a>
+        </div>
+    </div>
+
+    {% if error %}
+    <div class="alert alert-warning">
+        <i class="bi bi-exclamation-triangle me-2"></i>{{ error }}
+    </div>
+    {% elif raw_content %}
+    <pre class="p-3 rounded border"
+         style="background: var(--bs-tertiary-bg); font-size: 0.875rem;
+                white-space: pre-wrap; word-break: break-word; overflow-x: auto;">{{ raw_content | e }}</pre>
+    {% else %}
+    <div class="text-muted fst-italic">This note is empty.</div>
+    {% endif %}
+</div>
+
+{% endblock %}

--- a/flask_templates/dataset_views/rga_tey_run_plots.html
+++ b/flask_templates/dataset_views/rga_tey_run_plots.html
@@ -1,0 +1,210 @@
+{% extends "base.html" %}
+{% block title %}{{ds['dataset_name']}} — RGA/TEY Plots{% endblock %}
+
+{% block head %}
+{{ super() }}
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+{% endblock %}
+
+{% block breadcrumb %}
+    <li class="breadcrumb-item"><a href="/{{project_id}}/"><b>Project</b> {{project_id}}</a></li>
+    <li class="breadcrumb-item"><a href="/{{project_id}}/dataset/{{ds['unique_id']}}"><b>Dataset</b> {{ds['dataset_name']}}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">RGA/TEY Plots</li>
+{% endblock %}
+
+{% block content %}
+
+<div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
+    <h1 class="fs-4 fw-semibold mb-0" style="overflow-wrap: break-word;">{{ds['dataset_name']}}</h1>
+    <a href="/{{project_id}}/dataset/{{ds['unique_id']}}"
+       class="btn btn-sm btn-outline-secondary flex-shrink-0">
+        <i class="bi bi-database me-1"></i>Dataset
+    </a>
+</div>
+
+{% if tey_found %}
+
+<div id="tey-plot" style="width:100%; height:480px;"></div>
+<div id="tey-error" class="alert alert-warning d-none"></div>
+
+<script>
+(async () => {
+    const url = `/dataset-view/rga-tey-run-plots/{{ project_id }}/{{ ds['unique_id'] }}/tey-data`;
+    let text;
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        text = await resp.text();
+    } catch (e) {
+        const el = document.getElementById('tey-error');
+        el.textContent = 'Failed to load TEY data: ' + e.message;
+        el.classList.remove('d-none');
+        return;
+    }
+
+    // Parse tab-separated file (header row: "Time,s\tTEY,A\tShutter")
+    const lines = text.trim().split('\n');
+    const time = [], tey = [], shutter = [];
+    for (let i = 1; i < lines.length; i++) {
+        const parts = lines[i].split('\t');
+        if (parts.length < 3) continue;
+        time.push(parseFloat(parts[0]));
+        tey.push(parseFloat(parts[1]));
+        shutter.push(parseInt(parts[2], 10));
+    }
+
+    // Find contiguous shutter-open (=1) intervals for shading
+    const shapes = [];
+    let spanStart = null;
+    for (let i = 0; i < shutter.length; i++) {
+        if (shutter[i] === 1 && spanStart === null) {
+            spanStart = time[i];
+        } else if (shutter[i] !== 1 && spanStart !== null) {
+            shapes.push({
+                type: 'rect', xref: 'x', yref: 'paper',
+                x0: spanStart, x1: time[i - 1],
+                y0: 0, y1: 1,
+                fillcolor: 'rgba(255, 200, 0, 0.15)',
+                line: { width: 0 },
+                layer: 'below',
+            });
+            spanStart = null;
+        }
+    }
+    if (spanStart !== null) {
+        shapes.push({
+            type: 'rect', xref: 'x', yref: 'paper',
+            x0: spanStart, x1: time[time.length - 1],
+            y0: 0, y1: 1,
+            fillcolor: 'rgba(255, 200, 0, 0.15)',
+            line: { width: 0 },
+            layer: 'below',
+        });
+    }
+
+    const trace = {
+        x: time,
+        y: tey,
+        type: 'scattergl',
+        mode: 'lines',
+        name: 'TEY',
+        line: { color: '#0d6efd', width: 1.5 },
+    };
+
+    const layout = {
+        xaxis: { title: { text: 'Time (s)' }, showgrid: true },
+        yaxis: { title: { text: 'TEY (A)' }, showgrid: true, exponentformat: 'e' },
+        shapes,
+        legend: { orientation: 'h', y: -0.15 },
+        margin: { t: 30, r: 20, b: 60, l: 80 },
+        hovermode: 'x unified',
+        annotations: shapes.length ? [{
+            xref: 'paper', yref: 'paper',
+            x: 1, y: 1.02, xanchor: 'right', yanchor: 'bottom',
+            text: '<span style="background:rgba(255,200,0,0.3);padding:2px 6px;border-radius:3px;">■</span> Shutter open',
+            showarrow: false,
+            font: { size: 12 },
+        }] : [],
+    };
+
+    Plotly.newPlot('tey-plot', [trace], layout, { responsive: true });
+})();
+</script>
+
+{% else %}
+<div class="alert alert-warning">
+    <i class="bi bi-exclamation-triangle me-2"></i>No TEY data file found for this dataset.
+</div>
+{% endif %}
+
+<hr class="my-4">
+
+<h2 class="fs-5 fw-semibold mb-3">RGA Mass Spectrum</h2>
+
+{% if rga_found %}
+
+<div id="rga-summed" style="width:100%; height:380px;" class="mt-4"></div>
+<div id="rga-heatmap" style="width:100%; height:520px;"></div>
+<div id="rga-error" class="alert alert-warning d-none"></div>
+
+<script>
+(async () => {
+    const url = `/dataset-view/rga-tey-run-plots/{{ project_id }}/{{ ds['unique_id'] }}/rga-data`;
+    let text;
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        text = await resp.text();
+    } catch (e) {
+        const el = document.getElementById('rga-error');
+        el.textContent = 'Failed to load RGA data: ' + e.message;
+        el.classList.remove('d-none');
+        return;
+    }
+
+    // Line 0: instrument metadata (skip)
+    // Line 1: headers — "Time", "1", "2", ..., "300"
+    // Lines 2+: "YYYY/MM/DD HH:MM:SS.d" <tab> val1 <tab> val2 ...
+    const lines = text.trim().split('\n');
+    const headers = lines[1].split('\t');
+    const massLabels = headers.slice(1).map(Number);  // [1, 2, ..., 300]
+
+    // Parse data rows — store raw linear values for summing, log values for heatmap
+    const timestamps = [];
+    const rawByMass = massLabels.map(() => []);  // linear pressure per mass per time
+
+    for (let i = 2; i < lines.length; i++) {
+        const parts = lines[i].split('\t');
+        if (parts.length < 2) continue;
+        const iso = parts[0].trim().replace(/(\d{4})\/(\d{2})\/(\d{2}) /, '$1-$2-$3T');
+        timestamps.push(new Date(iso).getTime());
+        for (let m = 0; m < massLabels.length; m++) {
+            rawByMass[m].push(parseFloat(parts[m + 1]));
+        }
+    }
+
+    const t0 = timestamps[0];
+    const elapsed = timestamps.map(t => (t - t0) / 1000);
+
+    // Heatmap: log10 of raw values (floor at 1e-13)
+    const zLog = rawByMass.map(row => row.map(v => Math.log10(Math.max(v, 1e-13))));
+
+    Plotly.newPlot('rga-heatmap', [{
+        x: elapsed,
+        y: massLabels,
+        z: zLog,
+        type: 'heatmap',
+        colorscale: 'Viridis',
+        colorbar: { title: { text: 'log₁₀ Pressure (Torr)', side: 'right' }, thickness: 18 },
+        hovertemplate: 'Time: %{x:.1f} s<br>Mass: %{y}<br>log₁₀P: %{z:.2f}<extra></extra>',
+    }], {
+        xaxis: { title: { text: 'Elapsed time (s)' } },
+        yaxis: { title: { text: 'Mass (amu)' }, dtick: 25 },
+        margin: { t: 20, r: 100, b: 60, l: 65 },
+    }, { responsive: true });
+
+    // Mean spectrum: average raw values across all time points per mass channel
+    const nTime = timestamps.length;
+    const mean = rawByMass.map(row => row.reduce((a, v) => a + Math.max(v, 0), 0) / nTime);
+
+    Plotly.newPlot('rga-summed', [{
+        x: massLabels,
+        y: mean,
+        type: 'bar',
+        marker: { color: '#0d6efd' },
+        hovertemplate: 'Mass: %{x}<br>Mean Pressure: %{y:.3e} Torr<extra></extra>',
+    }], {
+        xaxis: { title: { text: 'Mass (amu)' }, dtick: 25 },
+        yaxis: { title: { text: 'Mean Pressure (Torr)' }, type: 'log', exponentformat: 'e' },
+        margin: { t: 20, r: 20, b: 60, l: 80 },
+    }, { responsive: true });
+})();
+</script>
+
+{% else %}
+<div class="alert alert-warning">
+    <i class="bi bi-exclamation-triangle me-2"></i>No RGA histogram file found for this dataset.
+</div>
+{% endif %}
+
+{% endblock %}

--- a/flask_templates/project_graph.html
+++ b/flask_templates/project_graph.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% block title %}Project Graph – {{pc['project_id']}}{% endblock %}
+
+{% block head %}
+    {{ super() }}
+    {{ vite_tags() }}
+    <style>
+        #cy {
+            width: 100%;
+            height: 700px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            margin-bottom: 2rem;
+        }
+        .legend-dot {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 2px;
+            margin-right: 4px;
+        }
+    </style>
+{% endblock %}
+
+{% block breadcrumb %}
+    <li class="breadcrumb-item"><a href="/{{pc['project_id']}}/"><b>Project</b> {{pc['project_id']}}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Project Graph</li>
+{% endblock %}
+
+{% block content %}
+
+<h1>Project Graph – <em>{{pc['project_id']}}</em></h1>
+
+<div class="d-flex align-items-center gap-3 mb-2">
+    <button id="toggleLayoutBtn" class="btn btn-sm btn-secondary">Switch to Vertical Layout</button>
+    <span class="text-muted small">
+        <span class="legend-dot" style="background:#4a7ba7;"></span>Sample
+        &nbsp;
+        <span class="legend-dot" style="background:#5a9e6f;"></span>Dataset
+    </span>
+</div>
+
+<div id="cy" data-project-id="{{pc['project_id']}}"></div>
+
+<script type="module">
+  let cyInstance = null;
+
+  async function initGraph() {
+    const response = await fetch('/{{pc["project_id"]}}/api/project-graph-data');
+    const graphData = await response.json();
+
+    if (window.initEntityGraph) {
+      cyInstance = window.initEntityGraph('cy', graphData);
+    } else {
+      setTimeout(initGraph, 100);
+    }
+  }
+
+  document.getElementById('toggleLayoutBtn').addEventListener('click', function() {
+    if (cyInstance && cyInstance.toggleLayout) {
+      const newLayout = cyInstance.toggleLayout();
+      this.textContent = newLayout === 'LR' ? 'Switch to Vertical Layout' : 'Switch to Horizontal Layout';
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initGraph);
+  } else {
+    initGraph();
+  }
+</script>
+
+{% endblock %}

--- a/flask_templates/project_list.html
+++ b/flask_templates/project_list.html
@@ -66,30 +66,6 @@
         <div id="archivedList" style="display:none;" class="mb-4"></div>
     </div>
 
-    <div class="mt-5 pt-4 border-top">
-        <p class="text-muted small fw-semibold text-uppercase mb-3">
-            <i class="bi bi-grid-3x3-gap me-1"></i>Project-specific views
-        </p>
-        <div class="d-flex flex-wrap gap-3">
-            <div class="card border" style="min-width:220px; max-width:320px;">
-                <div class="card-body py-2 px-3">
-                    <div class="fw-semibold small mb-1">10k Perovskites</div>
-                    <div class="d-flex flex-column gap-1">
-                        <a href="/10k_perovskites/view/overview"
-                           class="btn btn-sm btn-outline-secondary text-start">
-                            <i class="bi bi-bar-chart me-1"></i>Overview
-                        </a>
-                        <a href="/10k_perovskites/view/thinfilm-gallery"
-                           class="btn btn-sm btn-outline-secondary text-start">
-                            <i class="bi bi-images me-1"></i>Thin Film Gallery
-                            <span class="text-muted ms-1 small">(slow)</span>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- back-to-top button -->
     <button id="backToTop" title="Back to top"
             onclick="window.scrollTo({top:0, behavior:'smooth'})"

--- a/flask_templates/project_overview.html
+++ b/flask_templates/project_overview.html
@@ -166,6 +166,16 @@
                 <i class="bi bi-chat-dots"></i> Chat
             </a>
         </div>
+        {% if custom_views %}
+        <div class="d-flex flex-wrap gap-2 border-top px-3 py-2"
+             style="background:var(--bs-tertiary-bg);">
+            {% for view in custom_views %}
+            <a href="{{ view.url }}" class="btn btn-sm btn-outline-secondary">
+                {% if view.icon %}<i class="bi {{ view.icon }} me-1"></i>{% endif %}{{ view.label }}
+            </a>
+            {% endfor %}
+        </div>
+        {% endif %}
     </div>
 
     <!-- ── tab switcher + expand/collapse (sticky) ────────────────────── -->

--- a/project_views/__init__.py
+++ b/project_views/__init__.py
@@ -1,0 +1,50 @@
+"""
+Pluggable project-specific views.
+
+Each module in this package provides views for one project.  To add views for
+a new project, drop a file named <project_id>.py into this directory.  It must
+expose:
+
+    PROJECT_ID : str
+        The project identifier (used as the url_prefix /<PROJECT_ID>/view).
+
+    create_blueprint(auth, helpers) -> flask.Blueprint
+        Factory that receives the OIDC auth object and a dict of shared helper
+        functions, and returns a configured Blueprint.
+
+Available helpers
+-----------------
+    get_project(project_id, include_metadata=False)
+    is_user_in_project(project_id)
+    get_project_sample_graph(project_id)
+    get_sample_lineage_graph(sample_id)
+    get_entity_graph_nx(entity_id)
+"""
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+# Maps project_id -> list of {label, url, icon} with absolute URLs
+_registry: dict = {}
+
+
+def register_all(app, auth, helpers):
+    """Auto-discover and register every project view blueprint."""
+    pkg_dir = Path(__file__).parent
+    for _, name, _ in pkgutil.iter_modules([str(pkg_dir)]):
+        module = importlib.import_module(f'project_views.{name}')
+        if hasattr(module, 'create_blueprint') and hasattr(module, 'PROJECT_ID'):
+            bp = module.create_blueprint(auth, helpers)
+            prefix = f'/{module.PROJECT_ID}/view'
+            app.register_blueprint(bp, url_prefix=prefix)
+            app.logger.info(f'Registered project views: {module.PROJECT_ID}')
+            if hasattr(module, 'VIEWS'):
+                _registry[module.PROJECT_ID] = [
+                    {**v, 'url': prefix + v['url']} for v in module.VIEWS
+                ]
+
+
+def get_views(project_id: str) -> list:
+    """Return the list of custom view dicts for a project, or [] if none."""
+    return _registry.get(project_id, [])

--- a/project_views/proj10k_perovskites.py
+++ b/project_views/proj10k_perovskites.py
@@ -1,0 +1,105 @@
+import networkx as nx
+import pandas
+from flask import Blueprint, render_template, abort, current_app
+
+PROJECT_ID = '10k_perovskites'
+
+VIEWS = [
+    {'label': 'Overview',          'url': '/overview',         'icon': 'bi-bar-chart'},
+    {'label': 'Thin Film Gallery', 'url': '/thinfilm-gallery', 'icon': 'bi-images'},
+]
+
+
+def create_blueprint(auth, helpers):
+    bp = Blueprint(f'proj_{PROJECT_ID}', __name__)
+
+    get_project = helpers['get_project']
+    is_user_in_project = helpers['is_user_in_project']
+    get_project_sample_graph = helpers['get_project_sample_graph']
+
+    @bp.route('/overview')
+    @auth.oidc_auth('orcid')
+    def overview():
+        if not is_user_in_project(PROJECT_ID):
+            abort(403)
+        pc = get_project(PROJECT_ID, include_metadata=True)
+        G = get_project_sample_graph(PROJECT_ID)
+
+        thin_films = [s for s in pc['samples'] if s['sample_name'].startswith('TF')]
+        thin_films.sort(key=lambda x: x['sample_name'])
+
+        rows = []
+        for s in thin_films:
+            ancestors = [pc['samples_by_id'][sid] for sid in nx.ancestors(G, s['unique_id'])]
+            descendants = [pc['samples_by_id'][sid] for sid in nx.descendants(G, s['unique_id'])]
+
+            solid_precursors = [s for s in ancestors if s['sample_name'].startswith('SP')]
+            precursor_compositions = []
+            try:
+                for sp in solid_precursors:
+                    for ds in sp['datasets']:
+                        if ds['measurement'] == 'Solid Precursor synthesis':
+                            full_ds = pc['datasets_by_id'][ds['unique_id']]
+                            precursor_compositions.append(full_ds['scientific_metadata']['name'])
+            except Exception as err:
+                print(f"Failed to get solid precursor details {s['sample_name']}: {err}")
+
+            if len(precursor_compositions) < 2:
+                precursor_compositions += [None] * (2 - len(precursor_compositions))
+
+            sr = [ds for ds in s['datasets'] if ds['measurement'] == 'spin_run']
+            if sr:
+                sr = pc['datasets_by_id'][sr[0]['unique_id']]
+                anneal_temp = sr['scientific_metadata']['heater_sv_temp']
+            else:
+                anneal_temp = '?'
+
+            rows.append({
+                'thin_film_sample_name': s['sample_name'],
+                'thin_film_unique_id': s['unique_id'],
+                'sp_A': precursor_compositions[0],
+                'sp_B': precursor_compositions[1],
+                'anneal_temp': anneal_temp,
+            })
+
+        df = pandas.DataFrame(rows)
+        return render_template('proj10k_templates/overview.html', pc=pc, tfs=thin_films, df=df)
+
+    @bp.route('/thinfilm-gallery')
+    @auth.oidc_auth('orcid')
+    def thinfilm_gallery():
+        if not is_user_in_project(PROJECT_ID):
+            abort(403)
+        pc = get_project(PROJECT_ID)
+
+        thin_films = [s for s in pc['samples'] if s['sample_name'].startswith('TF')]
+        thin_films.sort(key=lambda x: x['sample_name'])
+
+        img_dsid = {
+            tf['unique_id']: next(
+                (ds['unique_id'] for ds in tf['datasets'] if ds['measurement'] == 'sample well image'),
+                None
+            )
+            for tf in thin_films
+        }
+        batch = {}
+        dataset_ids = [dsid for dsid in img_dsid.values() if dsid]
+        if dataset_ids:
+            try:
+                batch = current_app.crucible_client._request(
+                    "POST", "/datasets/first_thumbnails", json=dataset_ids
+                )
+            except Exception:
+                pass
+
+        tf_thumbs = []
+        for tf in thin_films:
+            dsid = img_dsid.get(tf['unique_id'])
+            tn = dict(batch.get(dsid, {})) if dsid else {}
+            tn['sample_name'] = tf['sample_name']
+            tn['sample_url'] = f'/{PROJECT_ID}/sample-graph/{tf["unique_id"]}'
+            tf_thumbs.append(tn)
+
+        return render_template('proj10k_templates/thinfilm-gallery.html', tf_thumbs=tf_thumbs)
+
+    return bp


### PR DESCRIPTION
# Plug-in system for custom project and dataset views

# use new API endpoints for graphs

## Summary

This branch refactors the main Flask application into a plugin architecture
and adds several new features on top of it.

---

## Pluggable project views

Introduces `project_views/`, an auto-discovered package of Flask Blueprints
that provide project-specific pages. Dropping a module into the directory that
exposes `PROJECT_ID` and `create_blueprint(auth, helpers)` is sufficient to
register new routes at startup — no changes to the main app required.

The existing hardcoded 10k Perovskites views have been extracted from the main
app into `project_views/proj10k_perovskites.py` as the reference example.

## Pluggable dataset views

Introduces `dataset_views/`, following the same auto-discovery pattern keyed
by measurement type. Modules declare `MEASUREMENT_TYPES`, `URL_PREFIX`, and
`LABEL`; the registry accumulates multiple views per type so they can coexist.
The dataset page renders a link to each registered view.

Ships with two views for `MDNote` datasets:
- **mdnote** — renders the markdown file as HTML, resolving `[[dataset:...]]`
  and `[[sample:...]]` wiki-style links
- **mdnote_raw** — displays the raw markdown source

## LLM chat blueprint

All AI chat functionality (~300 lines) has been extracted from the main
application file into `chat_blueprint.py`, following the same plugin pattern.
The main app now registers it with a single `register_blueprint` call.

## RGA/TEY run plots

New dataset view for `automated_RGA_TEY_run` datasets, with three interactive
Plotly charts:

- **TEY vs time** — line plot with shutter-open intervals highlighted
- **RGA heatmap** — elapsed time × mass (1–300 amu), log₁₀ pressure as colour
- **RGA mean spectrum** — time-averaged pressure vs mass, log y-axis

GCS signed URLs are proxied server-side (`/tey-data`, `/rga-data` routes) to
avoid browser CORS restrictions.

## Project Graph page

New page at `/<project_id>/graph` that visualises the full project entity graph
using the `project_entity_graph` API endpoint.

## UI improvements

- Improved sample graph page layout and use of updated API graph endpoints
