### PR TITLE
Relationship panel UX overhaul

### DIFF
--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -322,6 +322,10 @@
         window.location.href = url;
     }
 
+    function escHtml(s) {
+        return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
     // ── relationship add — inline picker in right panel ───────────────────
     const _REL_ADD_TYPES = {
         samples:  [
@@ -337,11 +341,25 @@
     };
     let _relAddCtx = {};
 
+    function cgRelEditToggle(btn) {
+        const panel = btn.closest('.rel-panel');
+        const editing = panel.classList.toggle('rel-editing');
+        btn.classList.toggle('active', editing);
+        btn.querySelector('i').className = editing ? 'bi bi-pencil-fill' : 'bi bi-pencil';
+        if (editing) cgRelAddClose();
+    }
+
     function cgRelAddOpen(btn) {
         const picker  = document.getElementById('rel-add-picker');
         const typeEl  = document.getElementById('rel-add-type');
         const search  = document.getElementById('rel-add-search');
         const results = document.getElementById('rel-add-results');
+        // Exit edit mode when adding
+        const panel = picker.closest('.rel-panel');
+        if (panel && panel.classList.contains('rel-editing')) {
+            const editBtn = panel.querySelector('.rel-edit-btn');
+            if (editBtn) cgRelEditToggle(editBtn);
+        }
         _relAddCtx = { pid: btn.dataset.pid, sourceId: btn.dataset.sourceId, resType: btn.dataset.resType };
         typeEl.innerHTML = (_REL_ADD_TYPES[_relAddCtx.resType] || []).map(t =>
             `<option value="${t.type}" data-endpoint="${t.endpoint}">${t.label}</option>`
@@ -429,15 +447,15 @@
         const confirmEl = document.createElement('span');
         confirmEl.className = 'rel-confirm-btns';
         confirmEl.innerHTML =
-            `<span class="text-muted" style="font-size:var(--fs-xs);">Remove?</span>
-             <button class="btn btn-sm btn-danger py-0 px-2" style="font-size:var(--fs-xs);">Remove</button>
+            `<span class="text-danger" style="font-size:var(--fs-xs); opacity:0.7;">Remove?</span>
+             <button class="btn btn-sm btn-danger py-0 px-2" style="font-size:var(--fs-xs);"><i class="bi bi-trash3 me-1"></i>Remove</button>
              <button class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size:var(--fs-xs);">Cancel</button>`;
         item.appendChild(confirmEl);
 
         confirmEl.querySelector('.btn-danger').addEventListener('click', async e => {
             e.stopPropagation();
             const { linkType, sourceId, targetId, pid } = item.dataset;
-            confirmEl.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+            confirmEl.innerHTML = '<span class="spinner-border spinner-border-sm text-danger"></span>';
             try {
                 const resp = await fetch(`/${pid}/api/relationships`, {
                     method: 'DELETE',

--- a/flask_templates/resource_base.html
+++ b/flask_templates/resource_base.html
@@ -209,14 +209,18 @@
       <i class="bi bi-diagram-3"></i>
       Relationships
       {% set total = (rel_parents|length) + (rel_children|length) + (rel_associated|length) %}
-      <span class="ms-auto d-flex align-items-center gap-2">
-        {% if total %}<span class="mfid" style="font-size: var(--fs-xs);">{{ total }}</span>{% endif %}
-        <button class="btn btn-sm px-2" style="font-size:var(--fs-sm); border:1px solid var(--cg-accent-mid); color:var(--cg-link); line-height:1.4;"
+      {% if total %}<span class="mfid" style="font-size: var(--fs-xs);">{{ total }}</span>{% endif %}
+      <span class="ms-auto d-flex align-items-center gap-1">
+        <button class="rel-panel-btn rel-edit-btn" onclick="cgRelEditToggle(this)" title="Toggle edit mode">
+          <i class="bi bi-pencil"></i>
+        </button>
+        <button class="rel-panel-btn rel-add-btn"
                 onclick="cgRelAddOpen(this)"
                 data-pid="{{pid}}"
                 data-source-id="{{res['unique_id']}}"
-                data-res-type="{{res_url_seg}}">
-          <i class="bi bi-plus"></i>Add
+                data-res-type="{{res_url_seg}}"
+                title="Add relationship">
+          <i class="bi bi-plus-lg"></i>
         </button>
       </span>
     </div>
@@ -253,7 +257,7 @@
              data-link-type="{{_parent_ltype}}" data-source-id="{{res['unique_id']}}" data-target-id="{{item['unique_id']}}" data-pid="{{pid}}">
           <i class="bi {{ rel_item_icon }}" style="font-size: var(--fs-xs); color:var(--cg-accent-mid); flex-shrink:0;"></i>
           <span class="rel-item-name"><span class="rel-item-name-text">{{item[rel_item_name_field]}}</span><span class="rel-item-sub mfid">{{item['unique_id']}}</span></span>
-          <button class="rel-remove-btn" onclick="cgRelRemove(event, this)" title="Remove relationship"><i class="bi bi-x"></i></button>
+          <button class="rel-remove-btn" onclick="cgRelRemove(event, this)" title="Remove relationship"><i class="bi bi-trash3"></i></button>
         </div>
         {% endfor %}
       </div>
@@ -276,7 +280,7 @@
              data-link-type="{{_child_ltype}}" data-source-id="{{res['unique_id']}}" data-target-id="{{item['unique_id']}}" data-pid="{{pid}}">
           <i class="bi {{ rel_item_icon }}" style="font-size: var(--fs-xs); color:var(--cg-accent-mid); flex-shrink:0;"></i>
           <span class="rel-item-name"><span class="rel-item-name-text">{{item[rel_item_name_field]}}</span><span class="rel-item-sub mfid">{{item['unique_id']}}</span></span>
-          <button class="rel-remove-btn" onclick="cgRelRemove(event, this)" title="Remove relationship"><i class="bi bi-x"></i></button>
+          <button class="rel-remove-btn" onclick="cgRelRemove(event, this)" title="Remove relationship"><i class="bi bi-trash3"></i></button>
         </div>
         {% endfor %}
       </div>
@@ -303,7 +307,7 @@
             <span class="rel-item-sub mfid">{{item['unique_id']}}</span>
             {% if item.get(rel_assoc_sub_field) %}<span class="rel-item-sub">{{item[rel_assoc_sub_field]}}</span>{% endif %}
           </span>
-          <button class="rel-remove-btn" onclick="cgRelRemove(event, this)" title="Remove relationship"><i class="bi bi-x"></i></button>
+          <button class="rel-remove-btn" onclick="cgRelRemove(event, this)" title="Remove relationship"><i class="bi bi-trash3"></i></button>
         </div>
         {% endfor %}
       </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -739,7 +739,7 @@ mark { background-color: var(--bs-warning-bg-subtle); color: var(--bs-warning-te
     color: var(--bs-body-color);
     border-bottom: 1px solid var(--bs-border-color);
     box-shadow: inset 3px 0 0 transparent;
-    transition: background 0.08s, box-shadow 0.1s, color 0.08s;
+    transition: background 0.06s, box-shadow 0.06s, color 0.06s;
 }
 .rel-item:last-child { border-bottom: none; }
 .rel-item:hover {
@@ -766,20 +766,32 @@ mark { background-color: var(--bs-warning-bg-subtle); color: var(--bs-warning-te
 .mfid > .rel-copy-btn { margin-left: 0.3rem; vertical-align: baseline; }
 .mfid:hover > .rel-copy-btn { opacity: 0.55; }
 .rel-remove-btn {
-    opacity: 0; flex-shrink: 0; border: none; background: none;
+    opacity: 0; pointer-events: none; flex-shrink: 0; border: none; background: none;
     padding: 0.15rem 0.35rem; border-radius: 3px;
-    color: var(--bs-secondary-color); cursor: pointer; font-size: var(--fs-md);
-    transition: opacity 0.15s, background 0.12s, color 0.12s; line-height: 1;
+    color: var(--bs-danger); cursor: pointer; font-size: var(--fs-sm);
+    transition: opacity 0.06s, background 0.06s; line-height: 1;
 }
-.rel-item:hover .rel-remove-btn { opacity: 0.6; }
-.rel-remove-btn:hover {
-    opacity: 1 !important;
-    background: rgba(220, 53, 69, 0.15);
-    color: var(--bs-danger);
-}
+.rel-remove-btn:hover { opacity: 1 !important; background: rgba(220,53,69,0.12); }
 .rel-item.rel-confirming { background: var(--bs-warning-bg-subtle); }
 .rel-item.rel-confirming .rel-copy-btn,
 .rel-item.rel-confirming .rel-remove-btn { display: none; }
+/* Edit-mode toggle: show all remove buttons with danger tint */
+.rel-panel.rel-editing .rel-remove-btn { opacity: 0.35; pointer-events: auto; background: rgba(220,53,69,0.06); }
+.rel-panel.rel-editing .rel-item:hover .rel-remove-btn { opacity: 0.7; }
+/* Icon-only panel action buttons */
+.rel-panel-btn {
+    display: flex; align-items: center; justify-content: center;
+    width: 24px; height: 24px; border-radius: 4px;
+    border: none; background: none; cursor: pointer; padding: 0;
+    font-size: var(--fs-md); line-height: 1; flex-shrink: 0;
+    transition: background 0.06s, color 0.06s, opacity 0.06s;
+}
+.rel-add-btn { color: var(--cg-accent-mid); opacity: 0.7; }
+.rel-add-btn:hover { background: color-mix(in srgb, var(--cg-accent-mid) 14%, transparent); color: var(--cg-link); opacity: 1; }
+.rel-edit-btn { color: var(--bs-secondary-color); opacity: 0.45; }
+.rel-edit-btn:hover { background: var(--bs-tertiary-bg); color: var(--bs-body-color); opacity: 1; }
+.rel-edit-btn.active { color: var(--bs-danger); background: rgba(220,53,69,0.1); opacity: 1; }
+.rel-edit-btn.active:hover { background: rgba(220,53,69,0.18); }
 .rel-confirm-btns {
     display: flex; align-items: center; gap: 0.35rem;
     font-size: var(--fs-xs); flex-shrink: 0;


### PR DESCRIPTION
## Summary

- **Fix**: add-relationship search suggestions were never rendering (`escHtml` undefined — trapped inside command palette IIFE; added shared helper at outer script scope)
- **Edit mode**: replaces hover-reveal X buttons with an explicit Edit toggle — pencil activates `bi-trash3` delete buttons on all items; mutually exclusive with the add picker
- **Remove button hardening**: `opacity:0` + `pointer-events:none` by default so the invisible button can't be triggered by hovering its exact position; re-enabled only in `.rel-editing`
- **Icon-only action buttons**: `+Add` and `Edit` replaced with compact 24px icon buttons (`.rel-panel-btn`) with 60ms transitions
- **Deletion theme consistency**: remove buttons are always `var(--bs-danger)` red; confirmation chip has red "Remove?" label, `bi-trash3` icon on confirm, danger spinner
- **Count badge**: moved inline next to "Relationships" title (was flushed right with action buttons)
- **Transition speed**: all rel-panel transitions tightened from 0.08–0.15s → 0.06s