### PR TITLE
fix: responsive layout improvements for narrow and mid-size screens

### DIFF
--- a/flask_templates/project_overview.html
+++ b/flask_templates/project_overview.html
@@ -238,7 +238,7 @@ function toggleSidebar() {
 {% set title = project_meta.get('title') %}
 {% set pid   = pc['project_id'] %}
 
-<div class="d-flex gap-4 align-items-start" style="max-width: calc(860px + 1.5rem + 220px);">
+<div class="d-flex gap-4 align-items-start">
 <div style="max-width: 860px; flex: 1; min-width: 0;">
 
     <!-- ── project header card ────────────────────────────────────────── -->
@@ -320,7 +320,7 @@ function toggleSidebar() {
       </div>
 
       <!-- ── controls bar ──────────────────────────────────────────────────── -->
-      <div id="ctrlBar" class="d-flex align-items-center gap-1 px-2 border border-top-0 rounded-bottom"
+      <div id="ctrlBar" class="d-flex align-items-center gap-1 px-2 border border-top-0 rounded-bottom flex-wrap"
            style="background:var(--bs-tertiary-bg); min-height:2rem;">
 
         <button class="btn btn-sm btn-link text-muted py-0 px-1 d-flex align-items-center gap-1"
@@ -336,8 +336,8 @@ function toggleSidebar() {
             <span class="d-none d-lg-inline">Collapse</span>
         </button>
 
-        <div class="ms-auto d-flex align-items-center gap-2">
-            <span class="text-muted" style="font-size: var(--fs-xs); white-space:nowrap; letter-spacing:0.03em;">Group</span>
+        <div class="ms-auto d-flex align-items-center gap-2 flex-wrap">
+            <span class="text-muted d-none d-md-inline" style="font-size: var(--fs-xs); white-space:nowrap; letter-spacing:0.03em;">Group</span>
             <select class="form-select form-select-sm" id="sampleGroupBySelect"
                     style="font-size: var(--fs-sm); width:auto; padding-top:0.15rem; padding-bottom:0.15rem;"
                     onclick="event.stopPropagation()" onchange="onSettingChange()">
@@ -355,7 +355,7 @@ function toggleSidebar() {
                 <option value="owner_orcid">Owner</option>
                 <option value="timestamp">Date</option>
             </select>
-            <span class="text-muted" style="font-size: var(--fs-xs); white-space:nowrap; letter-spacing:0.03em;">Sort</span>
+            <span class="text-muted d-none d-md-inline" style="font-size: var(--fs-xs); white-space:nowrap; letter-spacing:0.03em;">Sort</span>
             <select class="form-select form-select-sm" id="sampleSortBySelect"
                     style="font-size: var(--fs-sm); width:auto; padding-top:0.15rem; padding-bottom:0.15rem;"
                     onclick="event.stopPropagation()" onchange="onSettingChange()">

--- a/flask_templates/resource_base.html
+++ b/flask_templates/resource_base.html
@@ -110,19 +110,19 @@
     <div class="res-section-header" onclick="toggleGraphSection(this)">
         <i class="bi bi-diagram-3 text-muted"></i>
         <span>{% block graph_section_title %}Entity Graph{% endblock %}</span>
-        <div class="d-flex gap-2 ms-auto me-2" onclick="event.stopPropagation()">
+        <div class="d-flex gap-1 ms-auto me-2 flex-wrap" onclick="event.stopPropagation()">
             {% block extra_graph_buttons %}{% endblock %}
-            <button id="toggleLayoutBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);">
-                <i class="bi bi-arrow-left-right me-1"></i>Vertical
+            <button id="toggleLayoutBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);" title="Toggle layout direction">
+                <i class="bi bi-arrow-left-right"></i><span class="cg-btn-label d-none d-lg-inline ms-1">Vertical</span>
             </button>
-            <button id="fitBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);">
-                <i class="bi bi-bounding-box me-1"></i>Fit
+            <button id="fitBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);" title="Fit graph">
+                <i class="bi bi-bounding-box"></i><span class="cg-btn-label d-none d-lg-inline ms-1">Fit</span>
             </button>
-            <button id="toggleThumbnailsBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);">
-                <i class="bi bi-image me-1"></i>Thumbnails
+            <button id="toggleThumbnailsBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);" title="Toggle thumbnails">
+                <i class="bi bi-image"></i><span class="cg-btn-label d-none d-lg-inline ms-1">Thumbnails</span>
             </button>
-            <button id="fullscreenBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);">
-                <i class="bi bi-fullscreen me-1"></i>Fullscreen
+            <button id="fullscreenBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);" title="Fullscreen">
+                <i class="bi bi-fullscreen"></i><span class="cg-btn-label d-none d-lg-inline ms-1">Fullscreen</span>
             </button>
         </div>
         <i class="bi bi-chevron-right res-section-chevron" style="margin-left: 0;"></i>

--- a/flask_templates/sample.html
+++ b/flask_templates/sample.html
@@ -87,8 +87,8 @@
 {% block graph_section_title %}Sample Graph{% endblock %}
 
 {% block extra_graph_buttons %}
-<button id="toggleDatasetsBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);">
-    <i class="bi bi-database me-1"></i>Show Datasets
+<button id="toggleDatasetsBtn" class="btn btn-sm btn-outline-secondary py-0 px-2" style="font-size: var(--fs-sm);" title="Toggle datasets">
+    <i class="bi bi-database"></i><span class="d-none d-lg-inline ms-1">Show Datasets</span>
 </button>
 {% endblock %}
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -144,6 +144,11 @@ a:hover { color: var(--cg-link-hover); }
 .cg-breadcrumb {
     font-size: var(--fs-sm); overflow: hidden;
 }
+/* On small screens, hide all but the last breadcrumb item to save navbar space */
+@media (max-width: 575.98px) {
+    .cg-breadcrumb .breadcrumb-item:not(:last-child) { display: none; }
+    .cg-breadcrumb .breadcrumb-item:last-child::before { display: none; }
+}
 .cg-breadcrumb .breadcrumb-item a {
     color: rgba(168,196,205,0.75); text-decoration: none;
     transition: color 0.15s;
@@ -281,6 +286,10 @@ a:hover { color: var(--cg-link-hover); }
     color: var(--cg-accent-mid); padding-top: 0.15rem;
 }
 [data-bs-theme="dark"] .meta-key { color: var(--cg-accent); }
+@media (max-width: 479px) {
+    .meta-row { flex-direction: column; gap: 0.05rem; }
+    .meta-key { min-width: 0; padding-top: 0.4rem; }
+}
 .meta-divider { display: flex; align-items: center; gap: 0.6rem; margin: 0.9rem 0 0.4rem; }
 .meta-divider-label {
     font-size: var(--fs-xs); font-weight: 700; text-transform: uppercase;
@@ -549,7 +558,7 @@ mark { background-color: var(--bs-warning-bg-subtle); color: var(--bs-warning-te
     border-top: 2px solid var(--bs-border-color);
     background: var(--bs-tertiary-bg);
 }
-.cg-sibling-nav { display: flex; align-items: center; gap: 0.3rem; position: relative; }
+.cg-sibling-nav { display: flex; align-items: center; gap: 0.3rem; position: relative; flex-wrap: wrap; }
 .cg-sib-btn {
     display: inline-flex; align-items: center; justify-content: center;
     width: 1.6rem; height: 1.6rem; border-radius: 0.25rem;
@@ -724,7 +733,7 @@ mark { background-color: var(--bs-warning-bg-subtle); color: var(--bs-warning-te
 
 /* ── relationship panel (right sidebar, xl+ screens) ───────────── */
 .rel-panel {
-    min-width: 340px; flex: 1; max-width: 500px;
+    min-width: clamp(280px, 28vw, 340px); flex: 1; max-width: 500px;
     background: color-mix(in srgb, var(--cg-accent) 5%, var(--bs-body-bg));
     border: 1px solid var(--bs-border-color);
     border-left: 2px solid color-mix(in srgb, var(--cg-accent-mid) 30%, transparent);


### PR DESCRIPTION
## Summary

- **Sibling nav** (`resource_base.html`): adds `flex-wrap` so prev/next buttons, Jump, and group-by select wrap instead of overflowing at narrow widths
- **Graph control buttons** (`resource_base.html`, `sample.html`): text labels hidden below `lg` breakpoint; icons always visible with `title` tooltips
- **Project overview controls bar** (`project_overview.html`): `flex-wrap` on `#ctrlBar` and its inner row; Group/Sort labels hidden below `md` to prevent content being pushed down at mid sizes
- **Navbar breadcrumb** (`styles.css`): collapses to last item only on `xs` screens (`<576px`)
- **Relationship panel** (`styles.css`): `min-width` uses `clamp(280px, 28vw, 340px)` to prevent horizontal scroll at ~1200px viewports
- **Metadata rows** (`styles.css`): stacks key/value vertically below 480px instead of cramping into narrow columns