### PR TITLE
feat: client-side timestamp localisation

### DIFF
--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -47,19 +47,6 @@ def humanize_size_filter(n):
     return humanize_size(n)
 
 
-@app.template_filter('humanize_date')
-def humanize_date_filter(value):
-    if not value:
-        return None
-    s = str(value)
-    # ISO datetime: take just the date part, format nicely
-    try:
-        from datetime import datetime
-        dt = datetime.fromisoformat(s.replace('Z', '+00:00'))
-        return dt.strftime('%b %-d, %Y')
-    except Exception:
-        return s[:10] if len(s) >= 10 else s
-
 
 app.jinja_env.globals['abbrev_name'] = abbrev_name
 

--- a/flask_templates/_create_panels.html
+++ b/flask_templates/_create_panels.html
@@ -279,7 +279,17 @@ function _cgNowLocal() {
 }
 function _cgToISO(dtLocal) {
     if (!dtLocal) return null;
-    return dtLocal.length === 16 ? dtLocal + ':00' : dtLocal;
+    // datetime-local gives local wall-clock time — convert to UTC ISO for the API
+    const d = new Date(dtLocal);
+    return isNaN(d.getTime()) ? null : d.toISOString();
+}
+function _cgToLocal(isoStr) {
+    // Convert a stored UTC/offset ISO string back to datetime-local format (YYYY-MM-DDTHH:MM)
+    if (!isoStr) return '';
+    const d = new Date(isoStr);
+    if (isNaN(d.getTime())) return '';
+    const pad = n => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
 // ── JSON metadata helpers ─────────────────────────────────────────────────────
@@ -613,7 +623,7 @@ function cgOpenSamplePanel(editData) {
     document.getElementById('sp-type').value      = d.sample_type   || '';
     document.getElementById('sp-desc').value      = d.description   || '';
     document.getElementById('sp-public').checked  = !!d.public;
-    document.getElementById('sp-timestamp').value = isEdit ? (d.timestamp || '').slice(0,16) : _cgNowLocal();
+    document.getElementById('sp-timestamp').value = isEdit ? _cgToLocal(d.timestamp) : _cgNowLocal();
     document.getElementById('sp-meta-json').value = isEdit && d.scientific_metadata
         ? JSON.stringify(d.scientific_metadata, null, 2) : '';
     document.getElementById('sp-type-results').style.display = 'none';
@@ -648,7 +658,7 @@ function cgOpenDatasetPanel(editData) {
     document.getElementById('ds-datatype').value    = d.data_type       || '';
     document.getElementById('ds-instrument').value  = d.instrument_name || '';
     document.getElementById('ds-public').checked    = !!d.public;
-    document.getElementById('ds-timestamp').value   = isEdit ? (d.timestamp || '').slice(0,16) : _cgNowLocal();
+    document.getElementById('ds-timestamp').value   = isEdit ? _cgToLocal(d.timestamp) : _cgNowLocal();
     document.getElementById('ds-meta-json').value   = isEdit && d.scientific_metadata
         ? JSON.stringify(d.scientific_metadata, null, 2) : '';
     document.getElementById('ds-measurement-results').style.display = 'none';

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -979,6 +979,35 @@
         window.addEventListener('resize', applyNavbarHeight);
     })();
     </script>
+    <script>
+    // ── client-side timestamp localisation ───────────────────────────────────
+    // Formats an ISO string (or free-form text) into the user's local timezone.
+    // opts.time=true  → include hours:minutes (for detail views)
+    // Returns null when the input is empty/null; returns the raw string on parse failure.
+    window.cgFmtTs = function(raw, opts) {
+        if (!raw) return null;
+        const s = String(raw).trim();
+        if (!s) return null;
+        // Assume UTC when there is no explicit timezone marker
+        const normalised = /[Z+\-]\d*$/.test(s.replace(/^\d{4}-\d{2}-\d{2}/, '')) ? s
+            : s.includes('T') ? s + 'Z'
+            : s;
+        const d = new Date(normalised);
+        if (isNaN(d.getTime())) return s; // unparseable — show as-is
+        const fmtOpts = { year: 'numeric', month: 'short', day: 'numeric' };
+        if (opts && opts.time) { fmtOpts.hour = '2-digit'; fmtOpts.minute = '2-digit'; }
+        try { return d.toLocaleString(undefined, fmtOpts); } catch { return s; }
+    };
+
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('time[data-cg-ts]').forEach(function(el) {
+            const raw = el.getAttribute('data-cg-ts');
+            const withTime = el.hasAttribute('data-cg-ts-time');
+            const fmt = window.cgFmtTs(raw, { time: withTime });
+            if (fmt !== null) el.textContent = fmt;
+        });
+    });
+    </script>
 {% block panels %}{% endblock %}
 </body>
 </html>

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -988,11 +988,11 @@
         if (!raw) return null;
         const s = String(raw).trim();
         if (!s) return null;
-        // Assume UTC when there is no explicit timezone marker
-        const normalised = /[Z+\-]\d*$/.test(s.replace(/^\d{4}-\d{2}-\d{2}/, '')) ? s
-            : s.includes('T') ? s + 'Z'
-            : s;
-        const d = new Date(normalised);
+        // Truncate microseconds (6 digits) to milliseconds (3) — JS Date can't parse them
+        let norm = s.replace(/(\.\d{3})\d+/, '$1');
+        // Assume UTC when there is no explicit timezone marker after the time part
+        if (norm.includes('T') && !/[Z+\-]\d{2}:\d{2}$|Z$/.test(norm)) norm += 'Z';
+        const d = new Date(norm);
         if (isNaN(d.getTime())) return s; // unparseable — show as-is
         const fmtOpts = { year: 'numeric', month: 'short', day: 'numeric' };
         if (opts && opts.time) { fmtOpts.hour = '2-digit'; fmtOpts.minute = '2-digit'; }

--- a/flask_templates/dataset.html
+++ b/flask_templates/dataset.html
@@ -65,7 +65,7 @@
 {{ mrow("Session",      ds.get('session_name')) }}
 {{ mrow("Instrument",   ds.get('instrument_name')) }}
 {{ mrow_link("Project", ds.get('project_id'), '/' + (ds.get('project_id') or '') + '/') }}
-{{ mrow("Timestamp",    ds.get('timestamp') | humanize_date) }}
+<div class="meta-row"><span class="meta-key">Timestamp</span><span class="text-break">{% if ds.get('timestamp') %}<time data-cg-ts="{{ ds['timestamp'] }}" data-cg-ts-time>{{ ds['timestamp'] }}</time>{% else %}<span class="text-muted">—</span>{% endif %}</span></div>
 
 {# ── Advanced toggle button ── #}
 <div class="mt-3 pt-2" style="border-top: 1px solid var(--bs-border-color);">
@@ -101,8 +101,8 @@
         <span class="meta-divider-label">Dates</span>
         <div class="meta-divider-line"></div>
     </div>
-    {{ mrow("Created",  ds.get('creation_time') | humanize_date) }}
-    {{ mrow("Modified", ds.get('modification_time') | humanize_date) }}
+    <div class="meta-row"><span class="meta-key">Created</span><span class="text-break">{% if ds.get('creation_time') %}<time data-cg-ts="{{ ds['creation_time'] }}" data-cg-ts-time>{{ ds['creation_time'] }}</time>{% else %}<span class="text-muted">—</span>{% endif %}</span></div>
+    <div class="meta-row"><span class="meta-key">Modified</span><span class="text-break">{% if ds.get('modification_time') %}<time data-cg-ts="{{ ds['modification_time'] }}" data-cg-ts-time>{{ ds['modification_time'] }}</time>{% else %}<span class="text-muted">—</span>{% endif %}</span></div>
 </div>
 {% endblock %}
 

--- a/flask_templates/instrument.html
+++ b/flask_templates/instrument.html
@@ -151,7 +151,7 @@
                     {% endif %}
                 </div>
                 {% if ds.get('timestamp') %}
-                <span class="text-muted small text-nowrap flex-shrink-0">{{ ds['timestamp'][:10] }}</span>
+                <time class="text-muted small text-nowrap flex-shrink-0" data-cg-ts="{{ ds['timestamp'] }}">{{ ds['timestamp'] }}</time>
                 {% endif %}
                 <span class="mfid small text-nowrap flex-shrink-0">{{ ds['unique_id'] }}</span>
             </a>

--- a/flask_templates/instrument_views/nirvana.html
+++ b/flask_templates/instrument_views/nirvana.html
@@ -17,11 +17,10 @@
 {% if datasets %}
 <div class="list-group">
     {% for ds in datasets %}
-    {% set date = ds.get('timestamp', '')[:10] %}
     <a href="/{{ ds.project_id }}/datasets/{{ ds.unique_id }}"
        class="list-group-item list-group-item-action py-2">
         <div class="d-flex align-items-center gap-3">
-            <span class="text-muted small text-nowrap" style="min-width: 6rem;">{{ date or '—' }}</span>
+            <span class="text-muted small text-nowrap" style="min-width: 6rem;">{% if ds.get('timestamp') %}<time data-cg-ts="{{ ds['timestamp'] }}">{{ ds['timestamp'] }}</time>{% else %}—{% endif %}</span>
             <div class="flex-grow-1 min-width-0">
                 <div class="fw-semibold text-truncate">{{ ds.dataset_name or ds.unique_id }}</div>
                 {% if ds.get('measurement') %}

--- a/flask_templates/instrument_views/team05_overview.html
+++ b/flask_templates/instrument_views/team05_overview.html
@@ -20,11 +20,10 @@
 <h2>Sessions</h2>
 <div class="list-group">
     {% for ds in datasets if ds.measurement == 'full team05 session' %}
-    {% set date = ds.get('timestamp', '')[:10] %}
     <a href="/{{ ds.project_id }}/datasets/{{ ds.unique_id }}"
        class="list-group-item list-group-item-action py-2">
         <div class="d-flex align-items-center gap-3">
-            <span class="text-muted small text-nowrap" style="min-width: 6rem;">{{ date or '—' }}</span>
+            <span class="text-muted small text-nowrap" style="min-width: 6rem;">{% if ds.get('timestamp') %}<time data-cg-ts="{{ ds['timestamp'] }}">{{ ds['timestamp'] }}</time>{% else %}—{% endif %}</span>
             <div class="flex-grow-1 min-width-0">
                 <div class="fw-semibold text-truncate">{{ ds.dataset_name or ds.unique_id }}</div>
                 {% if ds.get('measurement') %}
@@ -42,11 +41,10 @@
 <h2>All Datasets</h2>
 <div class="list-group">
     {% for ds in datasets %}
-    {% set date = ds.get('timestamp', '')[:10] %}
     <a href="/{{ ds.project_id }}/datasets/{{ ds.unique_id }}"
        class="list-group-item list-group-item-action py-2">
         <div class="d-flex align-items-center gap-3">
-            <span class="text-muted small text-nowrap" style="min-width: 6rem;">{{ date or '—' }}</span>
+            <span class="text-muted small text-nowrap" style="min-width: 6rem;">{% if ds.get('timestamp') %}<time data-cg-ts="{{ ds['timestamp'] }}">{{ ds['timestamp'] }}</time>{% else %}—{% endif %}</span>
             <div class="flex-grow-1 min-width-0">
                 <div class="fw-semibold text-truncate">{{ ds.dataset_name or ds.unique_id }}</div>
                 {% if ds.get('measurement') %}

--- a/flask_templates/project_overview.html
+++ b/flask_templates/project_overview.html
@@ -569,7 +569,7 @@ function toggleSidebar() {
         if (!val) return '(no date)';
         const d = new Date(val);
         if (isNaN(d)) return '(no date)';
-        return MONTH_NAMES[d.getUTCMonth()] + ' ' + d.getUTCFullYear();
+        return MONTH_NAMES[d.getMonth()] + ' ' + d.getFullYear();
     }
 
     const CROSS_PROJECT_LABEL = 'Linked from other projects';

--- a/flask_templates/sample.html
+++ b/flask_templates/sample.html
@@ -51,7 +51,7 @@
 {# ── Basic view ── #}
 {{ mrow("Type",        s.get('sample_type')) }}
 {{ mrow_link("Project", s.get('project_id'), '/' + (s.get('project_id') or '') + '/') }}
-{{ mrow("Timestamp",   s.get('timestamp') | humanize_date) }}
+<div class="meta-row"><span class="meta-key">Timestamp</span><span class="text-break">{% if s.get('timestamp') %}<time data-cg-ts="{{ s['timestamp'] }}" data-cg-ts-time>{{ s['timestamp'] }}</time>{% else %}<span class="text-muted">—</span>{% endif %}</span></div>
 {{ mrow("Description", s.get('description')) }}
 
 {# ── Advanced toggle button ── #}
@@ -79,8 +79,8 @@
         <span class="meta-divider-label">Dates</span>
         <div class="meta-divider-line"></div>
     </div>
-    {{ mrow("Created",  s.get('creation_time') | humanize_date) }}
-    {{ mrow("Modified", s.get('modification_time') | humanize_date) }}
+    <div class="meta-row"><span class="meta-key">Created</span><span class="text-break">{% if s.get('creation_time') %}<time data-cg-ts="{{ s['creation_time'] }}" data-cg-ts-time>{{ s['creation_time'] }}</time>{% else %}<span class="text-muted">—</span>{% endif %}</span></div>
+    <div class="meta-row"><span class="meta-key">Modified</span><span class="text-break">{% if s.get('modification_time') %}<time data-cg-ts="{{ s['modification_time'] }}" data-cg-ts-time>{{ s['modification_time'] }}</time>{% else %}<span class="text-muted">—</span>{% endif %}</span></div>
 </div>
 {% endblock %}
 

--- a/flask_templates/user.html
+++ b/flask_templates/user.html
@@ -267,7 +267,7 @@
                         <span class="mfid">{{ item.pid }}</span>
                     </div>
                 </div>
-                <span class="text-muted small text-nowrap flex-shrink-0">{{ item.ts | humanize_date }}</span>
+                <time class="text-muted small text-nowrap flex-shrink-0" data-cg-ts="{{ item.ts }}">{{ item.ts }}</time>
             {% if item.pid %}</a>{% else %}</div>{% endif %}
             {% endfor %}
             {% if activity | length > 20 %}
@@ -378,7 +378,7 @@
                     </div>
                 </div>
                 {% if ds.get('timestamp') %}
-                <span class="text-muted small text-nowrap flex-shrink-0">{{ ds['timestamp'] | humanize_date }}</span>
+                <time class="text-muted small text-nowrap flex-shrink-0" data-cg-ts="{{ ds['timestamp'] }}">{{ ds['timestamp'] }}</time>
                 {% endif %}
                 <span class="mfid small text-nowrap flex-shrink-0">{{ ds['unique_id'] }}</span>
             </a>
@@ -419,7 +419,7 @@
                     </div>
                 </div>
                 {% if s.get('timestamp') %}
-                <span class="text-muted small text-nowrap flex-shrink-0">{{ s['timestamp'] | humanize_date }}</span>
+                <time class="text-muted small text-nowrap flex-shrink-0" data-cg-ts="{{ s['timestamp'] }}">{{ s['timestamp'] }}</time>
                 {% endif %}
                 <span class="mfid small text-nowrap flex-shrink-0">{{ s['unique_id'] }}</span>
             </a>


### PR DESCRIPTION
## Summary

- All timestamps are now displayed in the user's browser timezone via `<time data-cg-ts="ISO">` elements hydrated by `window.cgFmtTs()` in `base.html`
- Detail views (sample, dataset) show date + hours:minutes; list views (user, instrument, project overview) show date only
- Group-by-month bucketing in project overview fixed to use local month instead of UTC
- Create/edit panels now send proper UTC ISO to the API (`_cgToISO` via `Date.toISOString()`), and pre-fill the timestamp input in local time when editing an existing record
- Removes the server-side `humanize_date` Jinja2 filter
- Graceful degradation: unparseable strings (free-form text) are shown as-is; raw ISO is the fallback before JS runs