### PR TITLE
feat: username support — display, edit, account setup, availability check

### DIFF
--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -370,7 +370,8 @@ def check_username():
         # A match on your own ORCID is not "taken" — it's your current username
         taken = any(r.get('username') == q and r.get('orcid') != own_orcid for r in results)
         return jsonify({'available': not taken})
-    except Exception:
+    except Exception as e:
+        app.logger.warning("check_username failed for %r: %s", q, e)
         return jsonify({'available': None})
 
 

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -369,7 +369,7 @@ def check_username():
         own_orcid = user_session.userinfo.get('sub', '')
         results = get_user_client().users.search(q) or []
         # A match on your own ORCID is not "taken" — it's your current username
-        taken = any(r.get('username') == q and (r.get('orcid') or r.get('unique_id')) != own_orcid for r in results)
+        taken = any(r.get('username') == q and r.get('unique_id') != own_orcid for r in results)
         return jsonify({'available': not taken})
     except Exception as e:
         app.logger.warning("check_username failed for %r: %s", q, e)

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -289,7 +289,11 @@ def account_setup():
                 return redirect(request.script_root + '/')
             except Exception as e:
                 app.logger.error("Account creation failed for %s: %s", orcid, e)
-                error = 'Account creation failed. Please try again.'
+                err = str(e).lower()
+                if username and any(w in err for w in ('conflict', '409', 'already', 'taken', 'unique', 'duplicate')):
+                    error = f'Username @{username} is already taken — please choose a different one.'
+                else:
+                    error = 'Account creation failed. Please try again.'
         return render_template('account_setup.html',
                                orcid=orcid,
                                first_name=first_name,
@@ -346,7 +350,24 @@ def update_profile():
         return redirect(f'{request.script_root}/user/{orcid}?updated=1')
     except Exception as e:
         app.logger.error("Profile update failed for %s: %s", orcid, e)
+        err = str(e).lower()
+        if username and any(w in err for w in ('conflict', '409', 'already', 'taken', 'unique', 'duplicate')):
+            return redirect(f'{request.script_root}/user/{orcid}?update_error=1&error_msg=username_taken')
         return redirect(f'{request.script_root}/user/{orcid}?update_error=1')
+
+
+@app.route('/api/check-username')
+@auth.oidc_auth('orcid')
+def check_username():
+    q = request.args.get('q', '').strip().lower()
+    if not _USERNAME_RE.match(q):
+        return jsonify({'available': False})
+    try:
+        results = get_user_client().users.search(q) or []
+        taken = any(r.get('username') == q for r in results)
+        return jsonify({'available': not taken})
+    except Exception:
+        return jsonify({'available': None})
 
 
 @app.route('/profile')

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -228,6 +228,9 @@ def logout():
     return redirect(url_for('login'))
 
 
+_USERNAME_RE = re.compile(r'^[a-z0-9_-]{3,32}$')
+
+
 def _suggest_username(admin_client, email: str, first: str, last: str) -> str:
     """Return the first available username derived from email or name."""
     if email and '@' in email:
@@ -271,6 +274,8 @@ def account_setup():
             error = 'First name is required.'
         elif not last_name:
             error = 'Last name is required.'
+        elif username and not _USERNAME_RE.match(username):
+            error = 'Username must be 3–32 characters: lowercase letters, digits, hyphens, underscores.'
         if not error:
             try:
                 app.admin_client.users.create({
@@ -326,6 +331,9 @@ def update_profile():
     last_name  = request.form.get('last_name',  '').strip()
     email      = request.form.get('email',    '').strip()
     username   = request.form.get('username', '').strip()
+
+    if username and not _USERNAME_RE.match(username):
+        return redirect(f'{request.script_root}/user/{orcid}?update_error=1&error_msg=invalid_username')
 
     updates = {}
     if first_name: updates['first_name'] = first_name

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -162,12 +162,17 @@ def _crucible_user_exists(orcid):
     if flask.session.get('crucible_user_ok'):
         return True
     try:
-        app.admin_client.users.get(orcid)
+        if flask.session.get('crucible_apikey'):
+            # API key already bootstrapped — use self-service route, no admin needed
+            get_user_client().whoami()
+        else:
+            # First login: API key not in session yet, fall back to admin check
+            app.admin_client.users.get(orcid)
         flask.session['crucible_user_ok'] = True
         return True
     except Exception as e:
         err = str(e).lower()
-        if '404' in err or 'not found' in err:
+        if '404' in err or 'not found' in err or '401' in err:
             return False
         # Network / auth error — don't block login, log and proceed
         app.logger.warning("Could not verify Crucible account for %s: %s", orcid, e)

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -369,7 +369,7 @@ def check_username():
         own_orcid = user_session.userinfo.get('sub', '')
         results = get_user_client().users.search(q) or []
         # A match on your own ORCID is not "taken" — it's your current username
-        taken = any(r.get('username') == q and r.get('orcid') != own_orcid for r in results)
+        taken = any(r.get('username') == q and (r.get('orcid') or r.get('unique_id')) != own_orcid for r in results)
         return jsonify({'available': not taken})
     except Exception as e:
         app.logger.warning("check_username failed for %r: %s", q, e)

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -289,8 +289,9 @@ def account_setup():
                 return redirect(request.script_root + '/')
             except Exception as e:
                 app.logger.error("Account creation failed for %s: %s", orcid, e)
-                err = str(e).lower()
-                if username and any(w in err for w in ('conflict', '409', 'already', 'taken', 'unique', 'duplicate')):
+                resp = getattr(e, 'response', None)
+                status = getattr(resp, 'status_code', 0) if resp else 0
+                if username and status == 409:
                     error = f'Username @{username} is already taken — please choose a different one.'
                 else:
                     error = 'Account creation failed. Please try again.'

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 import flask
 import requests
@@ -222,6 +223,27 @@ def logout():
     return redirect(url_for('login'))
 
 
+def _suggest_username(admin_client, email: str, first: str, last: str) -> str:
+    """Return the first available username derived from email or name."""
+    if email and '@' in email:
+        base = email.split('@')[0].lower()
+    else:
+        base = f"{first}_{last}".lower() if first or last else ''
+    base = re.sub(r'[^a-z0-9_-]', '_', base)
+    base = re.sub(r'_+', '_', base).strip('_')[:28]
+    if len(base) < 3:
+        return ''
+    for i in range(1, 4):
+        candidate = base if i == 1 else f'{base}{i}'
+        try:
+            results = admin_client.users.search(candidate)
+            if not any(r.get('username') == candidate for r in (results or [])):
+                return candidate
+        except Exception:
+            return candidate
+    return base
+
+
 @app.route('/account/setup', methods=['GET', 'POST'])
 def account_setup():
     try:
@@ -237,7 +259,8 @@ def account_setup():
     if request.method == 'POST':
         first_name = request.form.get('first_name', '').strip()
         last_name  = request.form.get('last_name',  '').strip()
-        email      = request.form.get('email', '').strip()
+        email      = request.form.get('email',    '').strip()
+        username   = request.form.get('username', '').strip()
         error = None
         if not first_name:
             error = 'First name is required.'
@@ -249,7 +272,8 @@ def account_setup():
                     'unique_id':  orcid,
                     'first_name': first_name,
                     'last_name':  last_name,
-                    'email':      email or None,
+                    'email':      email    or None,
+                    'username':   username or None,
                 }, project_ids=[])
                 flask.session['crucible_user_ok'] = True
                 return redirect(request.script_root + '/')
@@ -261,20 +285,24 @@ def account_setup():
                                first_name=first_name,
                                last_name=last_name,
                                email=email,
+                               username=username,
                                error=error)
 
-    # GET — pre-fill from ORCID userinfo
+    # GET — pre-fill from ORCID userinfo and suggest a username
     given  = userinfo.get('given_name', '')
     family = userinfo.get('family_name', '')
     if not given and not family:
         parts  = (userinfo.get('name') or '').rsplit(' ', 1)
         given  = parts[0] if len(parts) > 0 else ''
         family = parts[1] if len(parts) > 1 else ''
+    email = userinfo.get('email', '')
+    suggested_username = _suggest_username(app.admin_client, email, given, family)
     return render_template('account_setup.html',
                            orcid=orcid,
                            first_name=given,
                            last_name=family,
-                           email=userinfo.get('email', ''),
+                           email=email,
+                           username=suggested_username,
                            error=None)
 
 

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -14,6 +14,7 @@ from flask_vite import Vite
 from werkzeug.middleware.proxy_fix import ProxyFix
 from crucible import CrucibleClient
 
+from utils.auth import get_user_client
 from utils.cache import clear_project_cache, get_project, is_user_in_project
 from utils.graph import get_entity_graph_nx, get_project_graph
 from utils.helpers import abbrev_name, humanize_size
@@ -290,15 +291,17 @@ def update_profile():
     orcid      = userinfo.get('sub', '')
     first_name = request.form.get('first_name', '').strip()
     last_name  = request.form.get('last_name',  '').strip()
-    email      = request.form.get('email', '').strip()
+    email      = request.form.get('email',    '').strip()
+    username   = request.form.get('username', '').strip()
 
     updates = {}
     if first_name: updates['first_name'] = first_name
     if last_name:  updates['last_name']  = last_name
-    updates['email'] = email or None
+    updates['email']    = email    or None
+    updates['username'] = username or None
 
     try:
-        app.admin_client.users.update(orcid, **updates)
+        get_user_client().account.update_profile(**updates)
         return redirect(f'{request.script_root}/user/{orcid}?updated=1')
     except Exception as e:
         app.logger.error("Profile update failed for %s: %s", orcid, e)

--- a/crucible_graph_explore_flask_app.py
+++ b/crucible_graph_explore_flask_app.py
@@ -350,8 +350,9 @@ def update_profile():
         return redirect(f'{request.script_root}/user/{orcid}?updated=1')
     except Exception as e:
         app.logger.error("Profile update failed for %s: %s", orcid, e)
-        err = str(e).lower()
-        if username and any(w in err for w in ('conflict', '409', 'already', 'taken', 'unique', 'duplicate')):
+        resp = getattr(e, 'response', None)
+        status = getattr(resp, 'status_code', 0) if resp else 0
+        if username and status == 409:
             return redirect(f'{request.script_root}/user/{orcid}?update_error=1&error_msg=username_taken')
         return redirect(f'{request.script_root}/user/{orcid}?update_error=1')
 
@@ -363,8 +364,11 @@ def check_username():
     if not _USERNAME_RE.match(q):
         return jsonify({'available': False})
     try:
+        user_session = UserSession(flask.session)
+        own_orcid = user_session.userinfo.get('sub', '')
         results = get_user_client().users.search(q) or []
-        taken = any(r.get('username') == q for r in results)
+        # A match on your own ORCID is not "taken" — it's your current username
+        taken = any(r.get('username') == q and r.get('orcid') != own_orcid for r in results)
         return jsonify({'available': not taken})
     except Exception:
         return jsonify({'available': None})

--- a/flask_templates/account_setup.html
+++ b/flask_templates/account_setup.html
@@ -56,10 +56,20 @@
                        value="{{ last_name or '' }}" required autocomplete="family-name">
             </div>
         </div>
-        <div class="mb-4">
+        <div class="mb-3">
             <label class="form-label small fw-semibold" for="email">Email <span class="text-muted fw-normal">(optional)</span></label>
             <input type="email" class="form-control" id="email" name="email"
                    value="{{ email or '' }}" autocomplete="email" placeholder="you@institution.edu">
+        </div>
+        <div class="mb-4">
+            <label class="form-label small fw-semibold" for="username">Username <span class="text-muted fw-normal">(optional)</span></label>
+            <div class="input-group">
+                <span class="input-group-text">@</span>
+                <input type="text" class="form-control" id="username" name="username"
+                       value="{{ username or '' }}" autocomplete="username"
+                       pattern="[a-z0-9_\-]{3,32}" placeholder="your-username">
+            </div>
+            <div class="form-text">3–32 chars: lowercase letters, digits, hyphens, underscores</div>
         </div>
 
         <button type="submit" class="btn btn-primary w-100">

--- a/flask_templates/account_setup.html
+++ b/flask_templates/account_setup.html
@@ -43,7 +43,7 @@
     </div>
 
     <!-- account creation form -->
-    <form method="POST" action="{{ url_for('account_setup') }}" novalidate>
+    <form method="POST" action="{{ url_for('account_setup') }}">
         <div class="row g-3 mb-3">
             <div class="col-6">
                 <label class="form-label small fw-semibold" for="first_name">First name <span class="text-danger">*</span></label>
@@ -67,9 +67,10 @@
                 <span class="input-group-text">@</span>
                 <input type="text" class="form-control" id="username" name="username"
                        value="{{ username or '' }}" autocomplete="username"
-                       pattern="[a-z0-9_\-]{3,32}" placeholder="your-username">
+                       pattern="[a-z0-9_\-]{3,32}" placeholder="your-username"
+                       oninput="cgUsernameInput(this)">
             </div>
-            <div class="form-text">3–32 chars: lowercase letters, digits, hyphens, underscores</div>
+            <div class="form-text" id="username-hint">3–32 chars: lowercase letters, digits, hyphens, underscores</div>
         </div>
 
         <button type="submit" class="btn btn-primary w-100">

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -264,7 +264,7 @@
                         if (el.value !== v) return; // value changed while fetching
                         if (data.available === true)       _setHint(false, true,  `@${v} is available`);
                         else if (data.available === false) _setHint(true,  false, `@${v} is already taken`);
-                        // null = unknown (network/error) — leave neutral
+                        // null = server couldn't check — stay neutral, don't block submit
                     })
                     .catch(() => _setHint(false, false, '3–32 chars: lowercase letters, digits, hyphens, underscores'));
             }, 400);

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -224,26 +224,30 @@
 
     // ── username input validation ─────────────────────────────────────────
     function cgUsernameInput(el) {
-        // Auto-lowercase and strip invalid characters as the user types
+        // Auto-lowercase only — never strip; show errors for invalid chars instead
         const pos = el.selectionStart;
-        const cleaned = el.value.toLowerCase().replace(/[^a-z0-9_-]/g, '');
-        if (cleaned !== el.value) {
-            el.value = cleaned;
-            el.setSelectionRange(pos, pos);
-        }
+        const lowered = el.value.toLowerCase();
+        if (lowered !== el.value) { el.value = lowered; el.setSelectionRange(pos, pos); }
+
         const hint = el.closest('.mb-3, .mb-4')?.querySelector('[id$="-hint"], .form-text');
-        if (!el.value) {
-            el.classList.remove('is-valid', 'is-invalid');
-            if (hint) { hint.className = 'form-text'; hint.textContent = '3–32 chars: lowercase letters, digits, hyphens, underscores'; }
-        } else if (el.value.length < 3) {
-            el.classList.add('is-invalid'); el.classList.remove('is-valid');
-            if (hint) { hint.className = 'form-text text-danger'; hint.textContent = 'Too short — minimum 3 characters'; }
-        } else if (el.value.length > 32) {
-            el.classList.add('is-invalid'); el.classList.remove('is-valid');
-            if (hint) { hint.className = 'form-text text-danger'; hint.textContent = 'Too long — maximum 32 characters'; }
+        const v = el.value;
+        let msg = '', bad = false, good = false;
+        if (!v) {
+            msg = '3–32 chars: lowercase letters, digits, hyphens, underscores';
+        } else if (/[^a-z0-9_-]/.test(v)) {
+            bad = true; msg = 'Only lowercase letters, digits, hyphens and underscores allowed';
+        } else if (v.length < 3) {
+            bad = true; msg = 'Too short — minimum 3 characters';
+        } else if (v.length > 32) {
+            bad = true; msg = 'Too long — maximum 32 characters';
         } else {
-            el.classList.add('is-valid'); el.classList.remove('is-invalid');
-            if (hint) { hint.className = 'form-text text-success'; hint.textContent = `@${el.value} looks good`; }
+            good = true; msg = `@${v} looks good`;
+        }
+        el.classList.toggle('is-invalid', bad);
+        el.classList.toggle('is-valid', good);
+        if (hint) {
+            hint.className = 'form-text' + (bad ? ' text-danger' : good ? ' text-success' : '');
+            hint.textContent = msg;
         }
     }
 

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -254,11 +254,10 @@
         } else if (v.length > 32) {
             _setHint(true, false, 'Too long — maximum 32 characters');
         } else {
-            // Format valid — show neutral hint while typing, check after pause
+            // Format valid — neutral hint while typing, update silently when check returns
             el.classList.remove('is-valid', 'is-invalid');
             if (hint) { hint.className = 'form-text'; hint.textContent = '3–32 chars: lowercase letters, digits, hyphens, underscores'; }
             _cgUnTimer[id] = setTimeout(() => {
-                if (hint) { hint.className = 'form-text text-muted'; hint.textContent = 'Checking…'; }
                 fetch(`${_CG_BASE}/api/check-username?q=${encodeURIComponent(v)}`)
                     .then(r => r.json())
                     .then(data => {

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -254,10 +254,11 @@
         } else if (v.length > 32) {
             _setHint(true, false, 'Too long — maximum 32 characters');
         } else {
-            // Format valid — debounce availability check
+            // Format valid — show neutral hint while typing, check after pause
             el.classList.remove('is-valid', 'is-invalid');
-            if (hint) { hint.className = 'form-text text-muted'; hint.textContent = 'Checking…'; }
+            if (hint) { hint.className = 'form-text'; hint.textContent = '3–32 chars: lowercase letters, digits, hyphens, underscores'; }
             _cgUnTimer[id] = setTimeout(() => {
+                if (hint) { hint.className = 'form-text text-muted'; hint.textContent = 'Checking…'; }
                 fetch(`${_CG_BASE}/api/check-username?q=${encodeURIComponent(v)}`)
                     .then(r => r.json())
                     .then(data => {

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -222,6 +222,31 @@
         if (chevron) chevron.style.color     = open ? '' : 'var(--bs-body-color)';
     }
 
+    // ── username input validation ─────────────────────────────────────────
+    function cgUsernameInput(el) {
+        // Auto-lowercase and strip invalid characters as the user types
+        const pos = el.selectionStart;
+        const cleaned = el.value.toLowerCase().replace(/[^a-z0-9_-]/g, '');
+        if (cleaned !== el.value) {
+            el.value = cleaned;
+            el.setSelectionRange(pos, pos);
+        }
+        const hint = el.closest('.mb-3, .mb-4')?.querySelector('[id$="-hint"], .form-text');
+        if (!el.value) {
+            el.classList.remove('is-valid', 'is-invalid');
+            if (hint) { hint.className = 'form-text'; hint.textContent = '3–32 chars: lowercase letters, digits, hyphens, underscores'; }
+        } else if (el.value.length < 3) {
+            el.classList.add('is-invalid'); el.classList.remove('is-valid');
+            if (hint) { hint.className = 'form-text text-danger'; hint.textContent = 'Too short — minimum 3 characters'; }
+        } else if (el.value.length > 32) {
+            el.classList.add('is-invalid'); el.classList.remove('is-valid');
+            if (hint) { hint.className = 'form-text text-danger'; hint.textContent = 'Too long — maximum 32 characters'; }
+        } else {
+            el.classList.add('is-valid'); el.classList.remove('is-invalid');
+            if (hint) { hint.className = 'form-text text-success'; hint.textContent = `@${el.value} looks good`; }
+        }
+    }
+
     // ── toast notifications ───────────────────────────────────────────────
     function cgToast(message, icon='bi-check-circle', duration=2200) {
         const container = document.getElementById('cg-toast-container');

--- a/flask_templates/base.html
+++ b/flask_templates/base.html
@@ -128,6 +128,7 @@
     {% endblock %}
 
     <script>
+    const _CG_BASE = {{ base | tojson }};
     // ── color & avatar utilities ──────────────────────────────────────────
     function hashColor(str) {
         // HSL-based: hue spans full spectrum, saturation 45-74% (never gray),
@@ -223,6 +224,7 @@
     }
 
     // ── username input validation ─────────────────────────────────────────
+    const _cgUnTimer = {};
     function cgUsernameInput(el) {
         // Auto-lowercase only — never strip; show errors for invalid chars instead
         const pos = el.selectionStart;
@@ -231,23 +233,41 @@
 
         const hint = el.closest('.mb-3, .mb-4')?.querySelector('[id$="-hint"], .form-text');
         const v = el.value;
-        let msg = '', bad = false, good = false;
-        if (!v) {
-            msg = '3–32 chars: lowercase letters, digits, hyphens, underscores';
-        } else if (/[^a-z0-9_-]/.test(v)) {
-            bad = true; msg = 'Only lowercase letters, digits, hyphens and underscores allowed';
-        } else if (v.length < 3) {
-            bad = true; msg = 'Too short — minimum 3 characters';
-        } else if (v.length > 32) {
-            bad = true; msg = 'Too long — maximum 32 characters';
-        } else {
-            good = true; msg = `@${v} looks good`;
+        const id = el.id || 'default';
+        clearTimeout(_cgUnTimer[id]);
+
+        function _setHint(bad, good, msg) {
+            el.classList.toggle('is-invalid', bad);
+            el.classList.toggle('is-valid', good);
+            if (hint) {
+                hint.className = 'form-text' + (bad ? ' text-danger' : good ? ' text-success' : '');
+                hint.textContent = msg;
+            }
         }
-        el.classList.toggle('is-invalid', bad);
-        el.classList.toggle('is-valid', good);
-        if (hint) {
-            hint.className = 'form-text' + (bad ? ' text-danger' : good ? ' text-success' : '');
-            hint.textContent = msg;
+
+        if (!v) {
+            _setHint(false, false, '3–32 chars: lowercase letters, digits, hyphens, underscores');
+        } else if (/[^a-z0-9_-]/.test(v)) {
+            _setHint(true, false, 'Only lowercase letters, digits, hyphens and underscores allowed');
+        } else if (v.length < 3) {
+            _setHint(true, false, 'Too short — minimum 3 characters');
+        } else if (v.length > 32) {
+            _setHint(true, false, 'Too long — maximum 32 characters');
+        } else {
+            // Format valid — debounce availability check
+            el.classList.remove('is-valid', 'is-invalid');
+            if (hint) { hint.className = 'form-text text-muted'; hint.textContent = 'Checking…'; }
+            _cgUnTimer[id] = setTimeout(() => {
+                fetch(`${_CG_BASE}/api/check-username?q=${encodeURIComponent(v)}`)
+                    .then(r => r.json())
+                    .then(data => {
+                        if (el.value !== v) return; // value changed while fetching
+                        if (data.available === true)       _setHint(false, true,  `@${v} is available`);
+                        else if (data.available === false) _setHint(true,  false, `@${v} is already taken`);
+                        // null = unknown (network/error) — leave neutral
+                    })
+                    .catch(() => _setHint(false, false, '3–32 chars: lowercase letters, digits, hyphens, underscores'));
+            }, 400);
         }
     }
 

--- a/flask_templates/project_overview.html
+++ b/flask_templates/project_overview.html
@@ -476,7 +476,11 @@ function toggleSidebar() {
                     <div class="fw-medium text-truncate" style="font-size: var(--fs-sm);">
                         {{ u.name or '—' }}
                     </div>
-                    {% if u.email %}
+                    {% if u.username %}
+                    <div class="text-muted text-truncate" style="font-size: var(--fs-xs);">
+                        @{{ u.username }}
+                    </div>
+                    {% elif u.email %}
                     <div class="text-muted text-truncate" style="font-size: var(--fs-xs);">
                         {{ u.email }}
                     </div>

--- a/flask_templates/user.html
+++ b/flask_templates/user.html
@@ -213,7 +213,7 @@
                         <input type="text" class="form-control" id="edit_username"
                                name="username" value="{{ username }}"
                                pattern="[a-z0-9_\-]{3,32}" autocomplete="username"
-                               placeholder="optional">
+                               placeholder="optional" oninput="cgUsernameInput(this)">
                     </div>
                     <div class="form-text" style="font-size: var(--fs-2xs);">3–32 chars: lowercase letters, digits, hyphens, underscores</div>
                 </div>
@@ -525,7 +525,12 @@
     // Toast feedback after profile update
     const params = new URLSearchParams(location.search);
     if (params.get('updated'))      cgToast('Profile updated', 'bi-check-circle');
-    if (params.get('update_error')) cgToast('Update failed — please try again', 'bi-exclamation-circle');
+    if (params.get('update_error')) {
+        const msg = params.get('error_msg') === 'invalid_username'
+            ? 'Invalid username — use 3–32 lowercase letters, digits, hyphens or underscores'
+            : 'Update failed — please try again';
+        cgToast(msg, 'bi-exclamation-circle', 4000);
+    }
 </script>
 
 {% endblock %}

--- a/flask_templates/user.html
+++ b/flask_templates/user.html
@@ -3,7 +3,8 @@
 {% set last      = user_info.get('last_name')  or '' %}
 {% set full_name = (first ~ ' ' ~ last).strip() %}
 {% set display   = full_name or target_orcid %}
-{% set email     = user_info.get('email') or '' %}
+{% set email     = user_info.get('email')    or '' %}
+{% set username  = user_info.get('username') or '' %}
 {% set initials  = ((first[:1] if first else '') ~ (last[:1] if last else '')) | upper or '?' %}
 {% block title %}{% if is_own_profile %}My Profile{% else %}{{ display }}{% endif %}{% endblock %}
 
@@ -147,7 +148,9 @@
                 <h1 class="fw-semibold mb-0" style="font-size: var(--fs-lg); letter-spacing:-0.01em; line-height:1.3;">
                     {{ full_name or '—' }}
                 </h1>
-                {% if email %}
+                {% if username %}
+                <div class="text-muted mt-1" style="font-size: var(--fs-sm);">@{{ username }}</div>
+                {% elif email %}
                 <div class="text-muted mt-1" style="font-size: var(--fs-sm);">{{ email }}</div>
                 {% endif %}
                 <div class="mfid mt-1" style="font-size: var(--fs-xs);">{{ target_orcid }}</div>
@@ -198,10 +201,21 @@
                     <input type="text" class="form-control form-control-sm" id="edit_last"
                            name="last_name" value="{{ last }}" required>
                 </div>
-                <div class="mb-3">
+                <div class="mb-2">
                     <label class="form-label small fw-semibold mb-1" for="edit_email">Email</label>
                     <input type="email" class="form-control form-control-sm" id="edit_email"
                            name="email" value="{{ email }}">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label small fw-semibold mb-1" for="edit_username">Username</label>
+                    <div class="input-group input-group-sm">
+                        <span class="input-group-text">@</span>
+                        <input type="text" class="form-control" id="edit_username"
+                               name="username" value="{{ username }}"
+                               pattern="[a-z0-9_\-]{3,32}" autocomplete="username"
+                               placeholder="optional">
+                    </div>
+                    <div class="form-text" style="font-size: var(--fs-2xs);">3–32 chars: lowercase letters, digits, hyphens, underscores</div>
                 </div>
                 <div class="d-flex gap-2">
                     <button type="submit" class="btn btn-primary btn-sm">
@@ -312,7 +326,9 @@
                     <i class="bi bi-person me-1"></i>User
                 </div>
                 <h1 class="fs-4 fw-semibold mb-0 lh-sm">{{ full_name or '—' }}</h1>
-                {% if email %}
+                {% if username %}
+                <div class="text-muted small mt-1">@{{ username }}</div>
+                {% elif email %}
                 <div class="text-muted small mt-1">{{ email }}</div>
                 {% endif %}
                 {% if target_orcid %}

--- a/flask_templates/user.html
+++ b/flask_templates/user.html
@@ -522,16 +522,23 @@
         navigator.clipboard.writeText(key).then(() => cgToast('API key copied', 'bi-clipboard-check'));
     }
 
-    // Toast feedback after profile update
-    const params = new URLSearchParams(location.search);
-    if (params.get('updated'))      cgToast('Profile updated', 'bi-check-circle');
-    if (params.get('update_error')) {
-        const msgs = {
-            invalid_username: 'Invalid username — use 3–32 lowercase letters, digits, hyphens or underscores',
-            username_taken:   'That username is already taken — please choose another',
-        };
-        cgToast(msgs[params.get('error_msg')] || 'Update failed — please try again', 'bi-exclamation-circle', 4000);
-    }
+    // Toast feedback after profile update — deferred so toast container is in DOM
+    document.addEventListener('DOMContentLoaded', () => {
+        const params = new URLSearchParams(location.search);
+        if (params.get('updated')) {
+            cgToast('Profile updated', 'bi-check-circle');
+        } else if (params.get('update_error')) {
+            const msgs = {
+                invalid_username: 'Invalid username — use 3–32 lowercase letters, digits, hyphens or underscores',
+                username_taken:   'That username is already taken — please choose another',
+            };
+            cgToast(msgs[params.get('error_msg')] || 'Update failed — please try again', 'bi-exclamation-circle', 4000);
+        }
+        // Clean up URL params without triggering a reload
+        if (params.get('updated') || params.get('update_error')) {
+            history.replaceState(null, '', location.pathname);
+        }
+    });
 </script>
 
 {% endblock %}

--- a/flask_templates/user.html
+++ b/flask_templates/user.html
@@ -526,10 +526,11 @@
     const params = new URLSearchParams(location.search);
     if (params.get('updated'))      cgToast('Profile updated', 'bi-check-circle');
     if (params.get('update_error')) {
-        const msg = params.get('error_msg') === 'invalid_username'
-            ? 'Invalid username — use 3–32 lowercase letters, digits, hyphens or underscores'
-            : 'Update failed — please try again';
-        cgToast(msg, 'bi-exclamation-circle', 4000);
+        const msgs = {
+            invalid_username: 'Invalid username — use 3–32 lowercase letters, digits, hyphens or underscores',
+            username_taken:   'That username is already taken — please choose another',
+        };
+        cgToast(msgs[params.get('error_msg')] || 'Update failed — please try again', 'bi-exclamation-circle', 4000);
     }
 </script>
 

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -113,14 +113,16 @@ def create_blueprint(auth):
                 uid = u.get('unique_id')
                 if not uid:
                     continue
-                first = u.get('first_name') or ''
-                last  = u.get('last_name')  or ''
-                name  = (first + ' ' + last).strip()
-                email = u.get('email') or ''
-                owner_map[uid] = name or email or uid
+                first    = u.get('first_name') or ''
+                last     = u.get('last_name')  or ''
+                name     = (first + ' ' + last).strip()
+                email    = u.get('email')    or ''
+                username = u.get('username') or ''
+                owner_map[uid] = name or username or email or uid
                 project_users.append({
                     'orcid':    uid,
                     'name':     name,
+                    'username': username,
                     'email':    email,
                     'initials': ((first[:1] if first else '') + (last[:1] if last else '')).upper() or '?',
                 })

--- a/routes/users.py
+++ b/routes/users.py
@@ -48,8 +48,7 @@ def create_blueprint(auth):
         user_projects = get_user_projects(orcid, client)
 
         if is_own_profile:
-            # Name/email already in the ORCID session — no member fetching needed.
-            # shared_projects is the full project list for own profile.
+            # Name/email from OIDC session; username requires an API call.
             info = user_session.userinfo
             given  = info.get('given_name', '')
             family = info.get('family_name', '')
@@ -57,17 +56,12 @@ def create_blueprint(auth):
                 parts = (info.get('name') or '').rsplit(' ', 1)
                 given  = parts[0] if parts else ''
                 family = parts[1] if len(parts) > 1 else ''
-            user_info = {
-                'first_name': given,
-                'last_name':  family,
-                'email':      info.get('email', ''),
-                'unique_id':  orcid,
-            }
             shared_projects = user_projects
 
             with ThreadPoolExecutor() as ex:
                 f_datasets = ex.submit(client.datasets.list, owner_orcid=orcid, limit=None)
                 f_samples  = ex.submit(client.samples.list,  owner_orcid=orcid, limit=None)
+                f_profile  = ex.submit(client.account.profile)
             try:
                 recent_datasets = f_datasets.result() or []
             except Exception:
@@ -76,6 +70,18 @@ def create_blueprint(auth):
                 recent_samples = f_samples.result() or []
             except Exception:
                 recent_samples = []
+            try:
+                api_profile = f_profile.result() or {}
+            except Exception:
+                api_profile = {}
+
+            user_info = {
+                'first_name': given,
+                'last_name':  family,
+                'email':      info.get('email', ''),
+                'unique_id':  orcid,
+                'username':   api_profile.get('username') or '',
+            }
 
         else:
             # Fetch user info directly + member lists to find shared projects.

--- a/routes/users.py
+++ b/routes/users.py
@@ -48,7 +48,7 @@ def create_blueprint(auth):
         user_projects = get_user_projects(orcid, client)
 
         if is_own_profile:
-            # Name/email from OIDC session; username requires an API call.
+            # Profile from account.profile(); OIDC session values are fallback only.
             info = user_session.userinfo
             given  = info.get('given_name', '')
             family = info.get('family_name', '')

--- a/routes/users.py
+++ b/routes/users.py
@@ -76,11 +76,11 @@ def create_blueprint(auth):
                 api_profile = {}
 
             user_info = {
-                'first_name': given,
-                'last_name':  family,
-                'email':      info.get('email', ''),
+                'first_name': api_profile.get('first_name') or given,
+                'last_name':  api_profile.get('last_name')  or family,
+                'email':      api_profile.get('email')      or info.get('email', ''),
                 'unique_id':  orcid,
-                'username':   api_profile.get('username') or '',
+                'username':   api_profile.get('username')   or '',
             }
 
         else:


### PR DESCRIPTION
## Summary

- Surfaces usernames across the app: profile cards, project member panel, owner fallback chain
- Profile edit form: `@username` field with real-time availability check (debounced, 400ms), auto-lowercase, format validation, specific error toasts
- Account setup: optional username field pre-filled with an availability-checked suggestion derived from email or name
- Profile update switches from `admin_client.users.update()` to `get_user_client().account.update_profile()` — the only endpoint that accepts username changes
- Own profile data sourced from `client.account.profile()` (API as truth), with OIDC session as fallback — fixes email field appearing blank in edit form
- `_crucible_user_exists` uses `whoami()` (self-service) when API key is in session; falls back to admin only on first login bootstrap
- Conflict detection uses HTTP 409 status code throughout, not string matching
- Availability check correctly excludes the user's own current username via `unique_id` comparison