### PR TITLE
SPLEEM viewers: rename sv_ramp viewer, fix layout, route legacy datasets

### DIFF
--- a/flask_templates/dataset_views/sv_ramp.html
+++ b/flask_templates/dataset_views/sv_ramp.html
@@ -33,7 +33,7 @@
 {% block content %}
 
 <div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
-    <h1 class="fs-4 fw-semibold mb-0" style="overflow-wrap:break-word;">{{ds['dataset_name']}}</h1>
+    <h1 class="fs-4 fw-semibold mb-0" style="overflow-wrap:break-word;"><i class="bi bi-activity me-1 text-primary"></i>{{ds['dataset_name']}}</h1>
     {% if project_id %}
     <a href="{{ base }}/{{project_id}}/datasets/{{ds['unique_id']}}" class="btn btn-sm btn-outline-secondary flex-shrink-0">
         <i class="bi bi-database me-1"></i>Dataset
@@ -41,17 +41,10 @@
     {% endif %}
 </div>
 
-<!-- ── IV curve ────────────────────────────────────────────────────────── -->
-<h2 class="fs-6 fw-semibold mb-1">IV Curve
-    <span class="text-muted fw-normal small">(click to jump to frame)</span>
-</h2>
-<div id="iv-plot" style="height:280px;"></div>
-
-<hr class="my-3">
-
-<!-- ── Frame image ─────────────────────────────────────────────────────── -->
-<div class="row g-3 align-items-start">
-    <div class="col-md-7">
+<!-- ── Frame viewer + IV curve (side by side) ─────────────────────────────── -->
+<div class="row g-3 justify-content-center">
+    <!-- Left: frame viewer -->
+    <div class="col-md-5">
 
         <!-- SV readout + nav -->
         <div class="d-flex align-items-center gap-2 mb-2 flex-wrap">
@@ -83,13 +76,21 @@
         <div id="frame-error" class="alert alert-warning mt-2 d-none"></div>
 
     </div>
+
+    <!-- Right: IV curve -->
+    <div class="col-md-5">
+        <h2 class="fs-6 fw-semibold mb-1">IV Curve
+            <span class="text-muted fw-normal small">(click to jump to frame)</span>
+        </h2>
+        <div id="iv-plot" style="height:280px;"></div>
+    </div>
 </div>
 
 <script>
 (function () {
     const dsid      = {{ ds['unique_id'] | tojson }};
     const projectId = {{ project_id | tojson }};
-    const base      = `{{ base }}/dataset-view/sv-ramp-gcs/${projectId}/${dsid}`;
+    const base      = `{{ base }}/dataset-view/sv-ramp/${projectId}/${dsid}`;
 
     const svArray   = {{ sv_array   | tojson }};
     const imavg     = {{ imavg_array | tojson }};

--- a/views/datasets/arres.py
+++ b/views/datasets/arres.py
@@ -15,7 +15,7 @@ from flask import Blueprint, abort, jsonify, render_template, request, send_from
 
 from utils.auth import get_user_client
 
-MEASUREMENT_TYPES = ['arres_ek', 'arres_mm']
+MEASUREMENT_TYPES = ['arres_ek', 'arres_mm', 'ARRES_EK', 'ARRES_MM']  # incl. pre-flip SF group names (old datasets)
 DATA_TYPE_STEMS = ['ScopeFoundryH5.qspleem_arres_ek', 'ScopeFoundryH5.qspleem_arres_mm']
 URL_PREFIX = '/dataset-view/arres'
 LABEL = 'ARRES Viewer'

--- a/views/datasets/spleem_image.py
+++ b/views/datasets/spleem_image.py
@@ -23,7 +23,7 @@ from flask import Blueprint, abort, jsonify, render_template, request, send_from
 
 from utils.auth import get_user_client
 
-MEASUREMENT_TYPES = ['spleem_image']
+MEASUREMENT_TYPES = ['spleem_image', 'SPLEEM_image']  # incl. pre-flip SF group name (old datasets)
 DATA_TYPE_STEMS = ['ScopeFoundryH5.qspleem_spleem_image']
 URL_PREFIX = '/dataset-view/spleem-image'
 LABEL = 'SPLEEM Image Viewer'

--- a/views/datasets/sv_ramp.py
+++ b/views/datasets/sv_ramp.py
@@ -27,7 +27,7 @@ from utils.auth import get_user_client
 
 MEASUREMENT_TYPES = ['sv_ramp']
 DATA_TYPE_STEMS = ['ScopeFoundryH5.qspleem_sv_ramp']
-URL_PREFIX = '/dataset-view/sv-ramp-gcs'
+URL_PREFIX = '/dataset-view/sv-ramp'
 LABEL = 'SV Ramp Viewer'
 
 # Directory of local .h5 files for the /local dev test route (not deployed to prod).
@@ -142,7 +142,7 @@ def _local_meta(filename: str, browser_url: str) -> dict:
 
 
 def create_blueprint(auth, helpers):
-    bp = Blueprint('dview_sv_ramp_gcs', __name__)
+    bp = Blueprint('dview_sv_ramp', __name__)
     is_user_in_project = helpers['is_user_in_project']
 
     @bp.route('/<project_id>/<dsid>')
@@ -153,7 +153,7 @@ def create_blueprint(auth, helpers):
         ds   = get_user_client().datasets.get(dsid)
         meta = _ensure_meta(dsid, get_user_client())
         return render_template(
-            'dataset_views/sv_ramp_gcs.html',
+            'dataset_views/sv_ramp.html',
             project_id=project_id,
             ds=ds,
             sv_array=meta['sv_array'],
@@ -183,7 +183,7 @@ def create_blueprint(auth, helpers):
         browser_url = f"{request.script_root}{URL_PREFIX}/localfile/{filename}"
         data = _local_meta(filename, browser_url)
         return render_template(
-            'dataset_views/sv_ramp_gcs.html',
+            'dataset_views/sv_ramp.html',
             project_id=None,
             ds={'dataset_name': filename, 'unique_id': None},
             sv_array=data['sv_array'],


### PR DESCRIPTION
- renamed sv_ramp viewer (sv_ramp_gcs -> sv_ramp (module, template, /dataset-view/sv-ramp prefix, blueprint)). gcs is a stale reference
- Give sv_ramp the same side-by-side layout as sv_ramp_spin (frame + IV curve) and the bi-activity header icon.
- Route legacy SPLEEM_image / ARRES_EK / ARRES_MM datasets (pre-flip measurement = SF group name) by adding those values to MEASUREMENT_TYPES; new datasets keep routing via the data_type stem.