### PR TITLE
Add "Open in Hyperspec" integration

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,13 +37,16 @@ steps:
         CHAT_MODEL=${_CHAT_MODEL},
         VERTEX_PROJECT_ID=${PROJECT_ID},
         VERTEX_REGION=${_REGION},
-        CRUCIBLE_DOWNLOAD_DIR=/tmp/crucible-downloads
+        CRUCIBLE_DOWNLOAD_DIR=/tmp/crucible-downloads,
+        HYPERSPEC_URL=${_HYPERSPEC_URL},
+        HYPERSPEC_BUCKET=app-hyperspec
       - '--set-secrets'
       - >-
         CRUCIBLE_API_KEY=crucible_admin_apikey:latest,
         PYOIDC_SECRET=pyoidc_secret_key:latest,
         ORCID_CLIENT_ID=orcid_client_id:latest,
-        ORCID_CLIENT_SECRET=orcid_client_secret:latest
+        ORCID_CLIENT_SECRET=orcid_client_secret:latest,
+        HYPERSPEC_SSO_SECRET=hyperspec_sso_secret:latest
       - '--service-account'
       - 'graph-explorer-cloudrun@mf-crucible.iam.gserviceaccount.com'
       - '--allow-unauthenticated'
@@ -54,5 +57,8 @@ substitutions:
   _IMAGE_PATH: '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_SERVICE_NAME}/app'
   _SERVICE_URL: 'https://${_SERVICE_NAME}-${PROJECT_NUMBER}.us-central1.run.app'
   _CHAT_MODEL: 'gemini-2.5-pro'
+  # Base URL of the Hyperspec Cloud Run service ("Open in Hyperspec" target).
+  # Empty disables the integration (the button is hidden).
+  _HYPERSPEC_URL: 'https://hyperspec-app-776258882599.us-central1.run.app'
 images:
   - '${_IMAGE_PATH}'

--- a/flask_templates/dataset.html
+++ b/flask_templates/dataset.html
@@ -316,6 +316,14 @@
                 {{file['size'] | humanize_size}}
             </span>
             {% if file.get('has_download_link') %}
+            {% if hyperspec_enabled and basename.lower().endswith(hyperspec_extensions) %}
+            <button class="btn btn-sm btn-outline-secondary border-0 border-start rounded-0 px-3"
+                    style="flex-shrink:0; height:100%; border-radius:0 !important;"
+                    onclick="openInHyperspec(event, '{{file['mfid']}}')"
+                    title="Open {{basename}} in Hyperspec">
+                <i class="bi bi-box-arrow-up-right"></i>
+            </button>
+            {% endif %}
             <button class="btn btn-sm btn-outline-secondary border-0 border-start rounded-0 px-3"
                     style="flex-shrink:0; height:100%; border-radius:0 !important;"
                     onclick="shareFile(event, '{{file['mfid']}}')"
@@ -471,6 +479,28 @@
         } finally {
             btn.disabled = false;
             icon.className = 'bi bi-download';
+        }
+    }
+
+    async function openInHyperspec(event, mfid) {
+        const btn = event.currentTarget;
+        const icon = btn.querySelector('i');
+        btn.disabled = true;
+        icon.className = 'bi bi-hourglass-split';
+        try {
+            const resp = await fetch(
+                '{{ base }}/{{project_id}}/datasets/{{ds["unique_id"]}}/files/' + mfid + '/open-in-hyperspec',
+                { method: 'POST' }
+            );
+            const data = await resp.json();
+            if (!resp.ok) throw new Error(data.error || ('HTTP ' + resp.status));
+            window.open(data.url, '_blank', 'noopener');
+            cgToast('Opened in Hyperspec', 'bi-box-arrow-up-right');
+        } catch (err) {
+            alert('Could not open in Hyperspec: ' + err.message);
+        } finally {
+            btn.disabled = false;
+            icon.className = 'bi bi-box-arrow-up-right';
         }
     }
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -7,8 +7,9 @@ def register_routes(app, auth, helpers=None):
     from .graphs      import create_blueprint as graphs_bp
     from .search      import create_blueprint as search_bp
     from .chat        import create_blueprint as chat_bp
+    from .hyperspec   import create_blueprint as hyperspec_bp
 
     for factory in [projects_bp, samples_bp, datasets_bp, users_bp,
-                    instruments_bp, graphs_bp, search_bp]:
+                    instruments_bp, graphs_bp, search_bp, hyperspec_bp]:
         app.register_blueprint(factory(auth))
     app.register_blueprint(chat_bp(auth, helpers or {}))

--- a/routes/hyperspec.py
+++ b/routes/hyperspec.py
@@ -1,0 +1,129 @@
+"""Open-in-Hyperspec integration.
+
+Hands a Crucible dataset file to the Hyperspec app (Cloud Run, same GCP
+project) without any browser download/upload.
+
+Trust chain
+-----------
+1. The user is ORCiD-authenticated here; authorization for the file is
+   delegated to the Crucible API by using the *user's own* API key
+   (get_user_client) — the admin key is never used for file access.
+2. The file is copied server-side from mf-storage-prod into Hyperspec's
+   bucket under incoming/<uuid>/ — this service account only needs
+   write-only (objectCreator) access there. If the copy is denied, we fall
+   back to passing the 1-hour signed download URL instead.
+3. The browser is redirected to {HYPERSPEC_URL}/import?token=... where the
+   token is a short-lived (Hyperspec enforces max_age) itsdangerous
+   signature over {orcid, name, object|signed_url, filename, crucible_dsid}
+   using the shared secret HYPERSPEC_SSO_SECRET. Hyperspec derives the
+   user's identity and storage namespace exclusively from this token.
+"""
+
+import logging
+import os
+import uuid
+
+import flask
+import fsspec
+from flask import Blueprint, abort, jsonify
+from flask_pyoidc.user_session import UserSession
+from itsdangerous import URLSafeTimedSerializer
+
+from utils.auth import get_user_client
+
+logger = logging.getLogger(__name__)
+
+HYPERSPEC_URL = os.getenv('HYPERSPEC_URL', '').rstrip('/')
+HYPERSPEC_SSO_SECRET = os.getenv('HYPERSPEC_SSO_SECRET', '')
+HYPERSPEC_BUCKET = os.getenv('HYPERSPEC_BUCKET', 'app-hyperspec')
+
+# File types Hyperspec can process (see hyperspec's precompute.process_h5)
+HYPERSPEC_EXTENSIONS = ('.h5', '.mat')
+
+
+def is_enabled() -> bool:
+    return bool(HYPERSPEC_URL and HYPERSPEC_SSO_SECRET)
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    return URLSafeTimedSerializer(HYPERSPEC_SSO_SECRET, salt='hyperspec-sso')
+
+
+def _current_user():
+    """Return (orcid, display_name) for the logged-in session."""
+    userinfo = UserSession(flask.session).userinfo
+    orcid = userinfo['sub']
+    name = (userinfo.get('name')
+            or (userinfo.get('given_name', '') + ' ' + userinfo.get('family_name', '')).strip()
+            or orcid)
+    return orcid, name
+
+
+def create_blueprint(auth):
+    bp = Blueprint('hyperspec', __name__)
+
+    @bp.app_context_processor
+    def inject_hyperspec_enabled():
+        return {'hyperspec_enabled': is_enabled(),
+                'hyperspec_extensions': HYPERSPEC_EXTENSIONS}
+
+    @bp.route("/<project_id>/datasets/<dsid>/files/<mfid>/open-in-hyperspec",
+              methods=['POST'])
+    @auth.oidc_auth('orcid')
+    def open_in_hyperspec(project_id, dsid, mfid):
+        if not is_enabled():
+            return jsonify({'error': 'Hyperspec integration is not configured'}), 503
+
+        client = get_user_client()
+        orcid, name = _current_user()
+
+        # Authorization gate: the file record is fetched with the user's own
+        # API key, so the Crucible API enforces project membership here.
+        files = client.datasets.get_associated_files(dsid)
+        frec = next((f for f in files if f.get('mfid') == mfid), None)
+        if frec is None:
+            abort(404)
+        storage_path = frec.get('storage_path')
+        if not storage_path:
+            return jsonify({'error': 'File has not been ingested yet'}), 409
+        basename = os.path.basename(frec.get('filename') or storage_path)
+        if not basename.lower().endswith(HYPERSPEC_EXTENSIONS):
+            return jsonify({'error': 'Only .h5 / .mat files can be opened in Hyperspec'}), 400
+
+        payload = {
+            'orcid': orcid,
+            'name': name,
+            'filename': basename,
+            'crucible_dsid': dsid,
+        }
+
+        # Preferred path: server-side GCS copy into Hyperspec's bucket.
+        try:
+            object_name = f'incoming/{uuid.uuid4()}/{basename}'
+            fsspec.filesystem('gcs').copy(storage_path,
+                                          f'{HYPERSPEC_BUCKET}/{object_name}')
+            payload['object'] = object_name
+        except Exception as err:
+            logger.warning("GCS copy to hyperspec bucket failed (%s); "
+                           "falling back to signed URL", err)
+            try:
+                payload['signed_url'] = client.files.get_download_link(mfid)
+            except Exception as err2:
+                logger.error("signed URL fallback also failed for %s: %s", mfid, err2)
+                return jsonify({'error': 'Could not make the file available to Hyperspec'}), 502
+
+        token = _serializer().dumps(payload)
+        return jsonify({'url': f'{HYPERSPEC_URL}/import?token={token}'})
+
+    @bp.route('/hyperspec/sso')
+    @auth.oidc_auth('orcid')
+    def hyperspec_sso():
+        """Login-only bounce: lets Hyperspec re-establish a session for a user
+        who is logged in here, without transferring any file."""
+        if not is_enabled():
+            abort(404)
+        orcid, name = _current_user()
+        token = _serializer().dumps({'orcid': orcid, 'name': name})
+        return flask.redirect(f'{HYPERSPEC_URL}/import?token={token}')
+
+    return bp


### PR DESCRIPTION
Per-file button on dataset pages hands .h5/.mat files to the Hyperspec Cloud Run app: the file record is authorized with the user's own API key, the object is copied server-side into Hyperspec's bucket (write-only grant; signed-URL fallback), and the browser follows a short-lived signed token that carries the user's ORCiD to Hyperspec's /import endpoint. Also adds /hyperspec/sso, a login-only bounce for Hyperspec's sign-in link. Disabled (button hidden) unless HYPERSPEC_URL and HYPERSPEC_SSO_SECRET are configured.

Need to run the commands below to ensure sufficient permissions are provided.
`gcloud run services update hyperspec-app --region us-central1 --set-env-vars CRUCIBLE_EXPLORE_URL=https://crucible.lbl.gov/explore --set-secrets SECRET_KEY=hyperspec_flask_secret_key:latest,HYPERSPEC_SSO_SECRET=hyperspec_sso_secret:latest`
`gsutil iam ch serviceAccount:graph-explorer-cloudrun@mf-crucible.iam.gserviceaccount.com:roles/storage.objectCreator gs://app-hyperspec`
`gcloud storage buckets add-iam-policy-binding gs://app-hyperspec --member="serviceAccount:hyperspec-runtime@mf-crucible.iam.gserviceaccount.com" --role="roles/storage.objectAdmin"`
